### PR TITLE
[장소 추가] UISearchController, UICollectionLayoutListConfiguration 도입

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096BB29235B08007426B1 /* SearchResultCell.swift */; };
 		B5C096C029236BC0007426B1 /* SearchResultCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096BF29236BC0007426B1 /* SearchResultCellViewModel.swift */; };
 		B5C096C429238091007426B1 /* SearchingLocationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096C329238091007426B1 /* SearchingLocationViewModel.swift */; };
-		B5C096C629238A0B007426B1 /* SearchingLocationViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096C529238A0B007426B1 /* SearchingLocationViewControllerDelegate.swift */; };
+		B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */; };
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
 		BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */; };
@@ -110,7 +110,7 @@
 		B5C096BB29235B08007426B1 /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
 		B5C096BF29236BC0007426B1 /* SearchResultCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCellViewModel.swift; sourceTree = "<group>"; };
 		B5C096C329238091007426B1 /* SearchingLocationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewModel.swift; sourceTree = "<group>"; };
-		B5C096C529238A0B007426B1 /* SearchingLocationViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewControllerDelegate.swift; sourceTree = "<group>"; };
+		B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewModelDelegate.swift; sourceTree = "<group>"; };
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
 		BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewController.swift; sourceTree = "<group>"; };
@@ -305,6 +305,7 @@
 			children = (
 				B5C096BF29236BC0007426B1 /* SearchResultCellViewModel.swift */,
 				B5C096C329238091007426B1 /* SearchingLocationViewModel.swift */,
+				B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -315,7 +316,6 @@
 				B5C096BB29235B08007426B1 /* SearchResultCell.swift */,
 				B5C096B729235428007426B1 /* SearchingLocationView.swift */,
 				B5C096B529235416007426B1 /* SearchingLocationViewController.swift */,
-				B5C096C529238A0B007426B1 /* SearchingLocationViewControllerDelegate.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -709,7 +709,7 @@
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
-				B5C096C629238A0B007426B1 /* SearchingLocationViewControllerDelegate.swift in Sources */,
+				B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */,
 				B5C096B829235428007426B1 /* SearchingLocationView.swift in Sources */,
 				A4CC04AA29221EEE00BB678B /* Location+CoreDataClass.swift in Sources */,
 				A4CC04A629221EEE00BB678B /* Travel+CoreDataClass.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
@@ -14,12 +14,16 @@ final class SearchingLocationView: UIView {
     // MARK: - UI Properties
     
     /// 검색 결과를 표시하는 컬렉션 뷰
-    lazy var searchResultCollectionView: UICollectionView = {
+    lazy var searchResultCollectionView: EmptyLabeledCollectionView = {
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
         configuration.showsSeparators = true
         
         let layout = UICollectionViewCompositionalLayout.list(using: configuration)
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        let collectionView = EmptyLabeledCollectionView(
+            emptyLabelText: StringLiteral.emptyLabelText,
+            frame: .zero,
+            collectionViewLayout: layout
+        )
         
         return collectionView
     }()
@@ -54,5 +58,11 @@ final class SearchingLocationView: UIView {
         searchResultCollectionView.snp.makeConstraints {
             $0.edges.equalTo(safeAreaLayoutGuide)
         }
+    }
+}
+
+fileprivate extension SearchingLocationView {
+    enum StringLiteral {
+        static let emptyLabelText = "장소 검색 결과가 없습니다."
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
@@ -13,24 +13,6 @@ final class SearchingLocationView: UIView {
     
     // MARK: - UI Properties
     
-    /// 서치바 텍스트필드 영역
-    let searchBarField: UITextField = {
-        let textField = UITextField()
-        textField.backgroundColor = .grey1
-        textField.layer.cornerRadius = Metric.searchBarCornerRadius
-        
-        let searchIconImageView = UIImageView(
-            image: UIImage(systemName: StringLiteral.searchBarIcon)
-        )
-        searchIconImageView.tintColor = .grey4
-        textField.leftView = searchIconImageView
-        textField.leftViewMode = .always
-        
-        textField.translatesAutoresizingMaskIntoConstraints = false
-        
-        return textField
-    }()
-    
     /// 검색 결과를 표시하는 컬렉션 뷰
     lazy var searchResultCollectionView: UICollectionView = {
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
@@ -39,23 +21,9 @@ final class SearchingLocationView: UIView {
         let layout = UICollectionViewCompositionalLayout.list(using: configuration)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         
-        return collectionView
-    }()
-    
-    /// 서치바 마진 영역
-    private let searchBarMarginView: UIView = {
-        let view = UIView()
-        return view
-    }()
-    
-    /// 서치바와 검색 결과 리스트를 포함하는 스택뷰
-    private let contentStack: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        stackView.spacing = Metric.contentStackSpacing
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
         
-        return stackView
+        return collectionView
     }()
     
     // MARK: - Init
@@ -81,40 +49,12 @@ final class SearchingLocationView: UIView {
     }
     
     private func configureSubviews() {
-        searchBarMarginView.addSubview(searchBarField)
-        
-        contentStack.addArrangedSubview(searchBarMarginView)
-        contentStack.addArrangedSubview(searchResultCollectionView)
-        
-        addSubview(contentStack)
+        addSubview(searchResultCollectionView)
     }
     
     private func configureConstraints() {
-        searchBarField.snp.makeConstraints {
-            $0.height.equalTo(Metric.searchBarHeight)
-            $0.horizontalEdges.equalTo(searchBarMarginView).inset(Metric.searchBarHorizontalPadding)
-            $0.verticalEdges.equalTo(searchBarMarginView)
-        }
-        
-        contentStack.snp.makeConstraints {
+        searchResultCollectionView.snp.makeConstraints {
             $0.edges.equalTo(safeAreaLayoutGuide)
         }
-        
-    }
-}
-
-// MARK: - Namespaces Extension
-
-extension SearchingLocationView {
-    enum Metric {
-        static let searchBarHorizontalPadding: CGFloat = 16
-        static let searchBarHeight: CGFloat = 36
-        static let searchBarCornerRadius: CGFloat = 10
-        
-        static let contentStackSpacing: CGFloat = 16
-    }
-    
-    enum StringLiteral {
-        static let searchBarIcon = "magnifyingglass"
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
@@ -21,8 +21,6 @@ final class SearchingLocationView: UIView {
         let layout = UICollectionViewCompositionalLayout.list(using: configuration)
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         
-        collectionView.translatesAutoresizingMaskIntoConstraints = false
-        
         return collectionView
     }()
     

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -42,17 +42,16 @@ final class SearchingLocationViewController: UIViewController {
     // MARK: - Configure Functions
     
     private func configureNavigationBar() {
-        title = "장소 검색"
+        title = StringLiteral.title
     }
     
     /// 서치바가 포함된 UISearchController를 설정한다.
     private func configureSearchController() {
         let searchController = UISearchController()
-        
         searchController.searchBar.delegate = self
         
         searchController.hidesNavigationBarDuringPresentation = false
-        searchController.searchBar.placeholder = "장소명을 입력해주세요."
+        searchController.searchBar.placeholder = StringLiteral.searchBarPlaceholder
         
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
@@ -105,6 +104,15 @@ final class SearchingLocationViewController: UIViewController {
         snapshot.appendItems(viewModel.searchResultCellViewModels)
         
         resultViewDataSource?.apply(snapshot)
+    }
+}
+
+// MARK: - Namespaces
+
+extension SearchingLocationViewController {
+    enum StringLiteral {
+        static let title = "장소 검색"
+        static let searchBarPlaceholder = "장소명을 입력해주세요."
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -34,7 +34,7 @@ final class SearchingLocationViewController: UIViewController {
         super.viewDidLoad()
         
         configureNavigationBar()
-        configureSearchBarFieldDelegate()
+        configureSearchController()
         configureCollectionView()
         configureViewModelDelegate()
     }
@@ -45,9 +45,17 @@ final class SearchingLocationViewController: UIViewController {
         title = "장소 검색"
     }
     
-    /// 서치바의 UITextFieldDelegate를 지정한다.
-    private func configureSearchBarFieldDelegate() {
-        rootView.searchBarField.delegate = self
+    /// 서치바가 포함된 UISearchController를 설정한다.
+    private func configureSearchController() {
+        let searchController = UISearchController()
+        
+        searchController.searchBar.delegate = self
+        
+        searchController.hidesNavigationBarDuringPresentation = false
+        searchController.searchBar.placeholder = "장소명을 입력해주세요."
+        
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
     }
     
     /// 컬렉션뷰 셀 등록, DiffableDataSource 정의, 델리게이트 지정을 수행한다.
@@ -108,18 +116,14 @@ extension SearchingLocationViewController {
     }
 }
 
-// MARK: - UITextFieldDelegate
+// MARK: - UISearchBarDelegate
 
-extension SearchingLocationViewController: UITextFieldDelegate {
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
-        
-        guard let keyword = textField.text
-        else { return true }
+extension SearchingLocationViewController: UISearchBarDelegate {
+    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        guard let keyword = searchBar.text
+        else { return }
         
         viewModel.fetchSearchResults(with: keyword)
-        
-        return true
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -8,13 +8,19 @@
 import UIKit
 
 final class SearchingLocationViewController: UIViewController {
+    
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, SearchResultCellViewModel>
+    typealias SnapShot = NSDiffableDataSourceSnapshot<Section, SearchResultCellViewModel>
+    typealias CellRegistration = UICollectionView
+                                    .CellRegistration<SearchResultCell, SearchResultCellViewModel>
+    
     // MARK: - UI Properties
     
     private let rootView = SearchingLocationView()
     
     // MARK: - Properties
     
-    private var resultViewDataSource: UICollectionViewDiffableDataSource<Section, SearchResultCellViewModel>?
+    private var resultViewDataSource: DataSource?
     
     private let viewModel = SearchingLocationViewModel()
     
@@ -60,13 +66,11 @@ final class SearchingLocationViewController: UIViewController {
     
     /// 컬렉션뷰에 사용될 셀을 등록하고, DiffableDataSource를 정의한다.
     private func configureCollectionViewDataSource() {
-        let cellRegistration = UICollectionView
-            .CellRegistration<SearchResultCell, SearchResultCellViewModel>(
-                handler: { cell, _, viewModel in
+        let cellRegistration = CellRegistration(handler: { cell, _, viewModel in
             cell.setupLabels(name: viewModel.name, address: viewModel.address)
         })
         
-        resultViewDataSource = UICollectionViewDiffableDataSource<Section, SearchResultCellViewModel>(
+        resultViewDataSource = DataSource(
             collectionView: rootView.searchResultCollectionView
         ) { collectionView, indexPath, itemIdentifier in
             let cell = collectionView.dequeueConfiguredReusableCell(
@@ -87,7 +91,7 @@ final class SearchingLocationViewController: UIViewController {
     
     /// 설정한 DiffableDataSource에 snapshot을 적용한다.
     private func configureSnapshot() {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, SearchResultCellViewModel>()
+        var snapshot = SnapShot()
         
         snapshot.appendSections([.main])
         snapshot.appendItems(viewModel.searchResultCellViewModels)

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -128,9 +128,9 @@ extension SearchingLocationViewController: UICollectionViewDelegate {
     }
 }
 
-// MARK: - SearchingLocationViewControllerDelegate
+// MARK: - SearchingLocationViewModelDelegate
 
-extension SearchingLocationViewController: SearchingLocationViewControllerDelegate {
+extension SearchingLocationViewController: SearchingLocationViewModelDelegate {
     func refreshSnapshot() {
         configureSnapshot()
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -147,6 +147,11 @@ extension SearchingLocationViewController: UICollectionViewDelegate {
 // MARK: - SearchingLocationViewModelDelegate
 
 extension SearchingLocationViewController: SearchingLocationViewModelDelegate {
+    
+    func checkSearchResultExisted() {
+        rootView.searchResultCollectionView.isEmpty = viewModel.searchResultCellViewModels.isEmpty
+    }
+    
     func refreshSnapshot() {
         configureSnapshot()
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -147,12 +147,11 @@ extension SearchingLocationViewController: UICollectionViewDelegate {
 // MARK: - SearchingLocationViewModelDelegate
 
 extension SearchingLocationViewController: SearchingLocationViewModelDelegate {
-    
-    func checkSearchResultExisted() {
+    func searchLocaitonResultDidChange() {
         rootView.searchResultCollectionView.isEmpty = viewModel.searchResultCellViewModels.isEmpty
     }
     
-    func refreshSnapshot() {
+    func searchLocationSnapshotDidRefresh() {
         configureSnapshot()
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -16,6 +16,7 @@ final class SearchingLocationViewModel {
     
     private(set) var searchResultCellViewModels: [SearchResultCellViewModel] = [] {
         didSet {
+            delegate?.checkSearchResultExisted()
             delegate?.refreshSnapshot()
         }
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -16,8 +16,8 @@ final class SearchingLocationViewModel {
     
     private(set) var searchResultCellViewModels: [SearchResultCellViewModel] = [] {
         didSet {
-            delegate?.checkSearchResultExisted()
-            delegate?.refreshSnapshot()
+            delegate?.searchLocaitonResultDidChange()
+            delegate?.searchLocationSnapshotDidRefresh()
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -25,17 +25,19 @@ final class SearchingLocationViewModel {
     /// 키워드를 통해 장소를 검색하고, 검색 결과값을 `searchResultCellViewModels`에 저장한다.
     /// - Parameter keyword: 입력된 키워드
     func fetchSearchResults(with keyword: String) {
-        // TODO: MKMapView 인스턴스를 생성만 하면 현재 위치 정보도 여기에 포함되는 걸까..? 아니라면 사용자의 현재 위치에 맞는 검색 결과를 보여주도록 수정 필요..
-        let mapView = MKMapView()
         let request = MKLocalSearch.Request()
         request.naturalLanguageQuery = keyword
-        request.region = mapView.region
+        request.region = MKCoordinateRegion(MKMapRect.world)
         
         let search = MKLocalSearch(request: request)
-        search.start { response, _ in
-            guard let response = response else {
+        search.start { response, error in
+            guard let response = response, error == nil
+            else {
+                // TODO: 에러 처리 필요
+                self.searchResultCellViewModels = []
                 return
             }
+            
             let cellViewModels = response.mapItems.map({
                 let placemark = $0.placemark
                 return SearchResultCellViewModel(
@@ -45,9 +47,6 @@ final class SearchingLocationViewModel {
                     longitude: placemark.coordinate.longitude
                 )
             })
-            mapView.removeAnnotations(mapView.annotations)
-            // [Memory] Resetting zone allocator with 32387 allocations still alive 경고가 떠서 추가
-            // removeAnnotations과 어떤 관련이 있는지는 아직 정확히 파악하지 못함..
             
             self.searchResultCellViewModels = cellViewModels
         }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -12,7 +12,7 @@ final class SearchingLocationViewModel {
     
     // MARK: - Properties
     
-    weak var delegate: SearchingLocationViewControllerDelegate?
+    weak var delegate: SearchingLocationViewModelDelegate?
     
     private(set) var searchResultCellViewModels: [SearchResultCellViewModel] = [] {
         didSet {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
@@ -1,5 +1,5 @@
 //
-//  SearchingLocationViewControllerDelegate.swift
+//  SearchingLocationViewModelDelegate.swift
 //  Doesaegim
 //
 //  Created by 서보경 on 2022/11/15.
@@ -7,6 +7,6 @@
 
 import Foundation
 
-protocol SearchingLocationViewControllerDelegate: AnyObject {
+protocol SearchingLocationViewModelDelegate: AnyObject {
     func refreshSnapshot()
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 protocol SearchingLocationViewModelDelegate: AnyObject {
+    func checkSearchResultExisted()
     func refreshSnapshot()
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol SearchingLocationViewModelDelegate: AnyObject {
-    func checkSearchResultExisted()
-    func refreshSnapshot()
+    func searchLocaitonResultDidChange()
+    func searchLocationSnapshotDidRefresh()
 }


### PR DESCRIPTION
## 변경사항
- 리뷰 피드백을 반영했습니다! (SearchingLocationViewControllerDelegate -> SearchingLocationViewModelDelegate로 네이밍 변경)
- SearchingLocationView에 있던 searchBarField를 제거한 대신 UISearchController를 도입했습니다.
- 기존의 CompositionalLayout을 직접 생성하는 방식 대신 재훈님이 말씀해주셨던 UICollectionLayoutListConfiguration을 도입했습니다.
- MKLocalSearch 시 메모리 경고가 뜨는 현상을 수정했습니다.
- 결과가 없을 경우 label을 표시하기 위해 선경님이 구현해주신 EmptyLabeledCollectionView를 사용했습니다.

## 관련 이슈
- resolves #12 

## 리뷰노트
- MKLocalSearch.Request를 다루면서 검색 범위를 사용자의 현재 위치 기준으로 해야한다는 생각에 삽질을 좀 많이 한 것 같습니다..😂
- MKLocalSearch.Request의 `region` 프로퍼티에 값을 지정해줌으로써 검색 범위를 좁힐 수 있다고 되어 있지만 저는 반대로 region에 값을 지정해주니 같은 키워드라도 해외 지역의 검색 결과값이 먼저 나타났고, region에 값을 지정해주지 않을 땐 국내 지역의 검색 결과가 우선적으로 나타났습니다. 이런 상황에 대해 검색해봐도 마땅한 답을 찾을 수가 없더라구요..🥲 우선은 값을 지정해줬지만 조금 더 알아봐야할 것 같습니다..ㅜㅜ
- UISearchController를 도입하는 과정에서 검색 결과를 표시하는 시기에 대해 고민했는데, 처음에는 단순히 `UISearchResultUpdating`을 채택받아 키워드가 변경될 때마다 검색 결과를 실시간으로 보여주려고 했지만 MKLocalSearch 역시 비동기 작업이다보니 일정 시간 내에 재호출하면 경고를 띄우는 것을 확인했습니다. 결국 기존의 방식대로 키워드가 모두 입력되고 난 뒤 Search 버튼을 터치하고 난 후 검색 결과를 받아올 수 있도록 `UISearchBarDelegate`를 채택 받아 관련 메서드를 구현했습니다.

## 스크린샷
지난 PR과 결과의 차이는 없어 스크린샷은 별도로 첨부하지 않았습니다!