### PR TITLE
[일정 목록] 코어데이터 호출 방식 변경 및 여행 목록, 일정 추가 화면과 연결 #13, #15

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A4CC04DE2923543500BB678B /* PlanListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04DD2923543500BB678B /* PlanListViewModel.swift */; };
 		A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04DF2923738500BB678B /* PlanLocalRepository.swift */; };
 		A4CC04E22923777B00BB678B /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04E12923777B00BB678B /* NSObject+Name.swift */; };
+		A4EB00DC2926456D00A83936 /* UIScrollView+DidPassPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB00DB2926456D00A83936 /* UIScrollView+DidPassPoint.swift */; };
 		B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D96252922301E00B510B8 /* TravelDTO.swift */; };
 		B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D9627292230CA00B510B8 /* PlanDTO.swift */; };
 		B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962B2922315500B510B8 /* LocationDTO.swift */; };
@@ -122,6 +123,7 @@
 		A4CC04DD2923543500BB678B /* PlanListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewModel.swift; sourceTree = "<group>"; };
 		A4CC04DF2923738500BB678B /* PlanLocalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanLocalRepository.swift; sourceTree = "<group>"; };
 		A4CC04E12923777B00BB678B /* NSObject+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
+		A4EB00DB2926456D00A83936 /* UIScrollView+DidPassPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+DidPassPoint.swift"; sourceTree = "<group>"; };
 		B57D96252922301E00B510B8 /* TravelDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDTO.swift; sourceTree = "<group>"; };
 		B57D9627292230CA00B510B8 /* PlanDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDTO.swift; sourceTree = "<group>"; };
 		B57D962B2922315500B510B8 /* LocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDTO.swift; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				A4CC04E12923777B00BB678B /* NSObject+Name.swift */,
 				A48E9947292515020029D57D /* UIViewController+PresentAlert.swift */,
 				A48E9949292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift */,
+				A4EB00DB2926456D00A83936 /* UIScrollView+DidPassPoint.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -841,6 +844,7 @@
 				EE116C592924AA0D0017B519 /* CustomCalendarHeaderView.swift in Sources */,
 				A4CC04A229221EEE00BB678B /* Diary+CoreDataClass.swift in Sources */,
 				EE116C5A2924AA0D0017B519 /* CustomCalendar.swift in Sources */,
+				A4EB00DC2926456D00A83936 /* UIScrollView+DidPassPoint.swift in Sources */,
 				EE3E29A829235F6B007C7FC7 /* UITextField+.swift in Sources */,
 				A4CC04822922191300BB678B /* PersistentManager.swift in Sources */,
 				A4CC04C929227C7200BB678B /* PlanCollectionViewCell.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A48E9946292512BC0029D57D /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E9945292512BC0029D57D /* CoreDataError.swift */; };
 		A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E9947292515020029D57D /* UIViewController+PresentAlert.swift */; };
+		A48E994A292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A48E9949292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift */; };
 		A4971D74291CC3A9008B337F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A4971D73291CC3A9008B337F /* .swiftlint.yml */; };
 		A4CC04822922191300BB678B /* PersistentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04812922191300BB678B /* PersistentManager.swift */; };
 		A4CC04A229221EEE00BB678B /* Diary+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC049829221EEE00BB678B /* Diary+CoreDataClass.swift */; };
@@ -98,6 +99,7 @@
 /* Begin PBXFileReference section */
 		A48E9945292512BC0029D57D /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
 		A48E9947292515020029D57D /* UIViewController+PresentAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PresentAlert.swift"; sourceTree = "<group>"; };
+		A48E9949292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+SetRightBarPlusButton.swift"; sourceTree = "<group>"; };
 		A4971D73291CC3A9008B337F /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A4CC04812922191300BB678B /* PersistentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentManager.swift; sourceTree = "<group>"; };
 		A4CC049829221EEE00BB678B /* Diary+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Diary+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -462,6 +464,7 @@
 				A4CC04D4292332C600BB678B /* UILabel+ChangeFontSize.swift */,
 				A4CC04E12923777B00BB678B /* NSObject+Name.swift */,
 				A48E9947292515020029D57D /* UIViewController+PresentAlert.swift */,
+				A48E9949292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -832,6 +835,7 @@
 				BBD0D061291DE988007D0D82 /* DiaryViewController.swift in Sources */,
 				EE116C582924AA0D0017B519 /* CustomCalendarCell.swift in Sources */,
 				B57D962E2922318F00B510B8 /* ExpenseDTO.swift in Sources */,
+				A48E994A292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift in Sources */,
 				B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */,
 				BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */,
 				EE116C592924AA0D0017B519 /* CustomCalendarHeaderView.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/xcshareddata/xcschemes/Doesaegim.xcscheme
+++ b/Doesaegim/Doesaegim.xcodeproj/xcshareddata/xcschemes/Doesaegim.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BBFAC082291CBDD700D7FD57"
+               BuildableName = "Doesaegim.app"
+               BlueprintName = "Doesaegim"
+               ReferencedContainer = "container:Doesaegim.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BBFAC082291CBDD700D7FD57"
+            BuildableName = "Doesaegim.app"
+            BlueprintName = "Doesaegim"
+            ReferencedContainer = "container:Doesaegim.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BBFAC082291CBDD700D7FD57"
+            BuildableName = "Doesaegim.app"
+            BlueprintName = "Doesaegim"
+            ReferencedContainer = "container:Doesaegim.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Doesaegim/Doesaegim/Presentation/MainTabBarController.swift
+++ b/Doesaegim/Doesaegim/Presentation/MainTabBarController.swift
@@ -26,7 +26,7 @@ final class MainTabBarController: UITabBarController {
     
     /// `MainTabBarController` 설정 함수
     private func configureTabBar() {
-        let travelPlanViewController = UINavigationController(rootViewController: PlanAddViewController())
+        let travelPlanViewController = UINavigationController(rootViewController: TravelListViewController())
         let expenseViewController = UINavigationController(rootViewController: ExpenseTravelListController())
         let mapViewController = UINavigationController(rootViewController: MapViewController())
         let diaryViewController = UINavigationController(rootViewController: DiaryViewController())

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -60,6 +60,10 @@ final class PlanListViewController: UIViewController {
 
     private func configureNavigationBar() {
         navigationItem.title = viewModel.navigationTitle
+        // TODO: 일정 추가 화면으로 교체
+        let nextViewController = UIViewController()
+        nextViewController.view.backgroundColor = .systemYellow
+        setRightBarAddButton(showing: nextViewController)
     }
 
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -60,10 +60,7 @@ final class PlanListViewController: UIViewController {
 
     private func configureNavigationBar() {
         navigationItem.title = viewModel.navigationTitle
-        // TODO: 일정 추가 화면으로 교체
-        let nextViewController = UIViewController()
-        nextViewController.view.backgroundColor = .systemYellow
-        setRightBarAddButton(showing: nextViewController)
+        setRightBarAddButton(showing: PlanAddViewController())
     }
 
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 /// 일정을 조회, 추가, 삭제할 수 있는 뷰 컨트롤러
 final class PlanListViewController: UIViewController {
     typealias DataSource =  UICollectionViewDiffableDataSource<Section, ItemID>
-    typealias Section = Int
+    typealias Section = String
     typealias ItemID = UUID
 
     // MARK: - UI Properties
@@ -27,6 +27,10 @@ final class PlanListViewController: UIViewController {
 
     private let viewModel: PlanListViewModel
 
+    private var sectionIdentifiers: [Section] {
+        dataSource.snapshot().sectionIdentifiers
+    }
+
 
     // MARK: - Init(s)
 
@@ -41,6 +45,7 @@ final class PlanListViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    
     // MARK: - Life Cycle
 
     override func loadView() {
@@ -51,6 +56,7 @@ final class PlanListViewController: UIViewController {
         super.viewDidLoad()
 
         configureNavigationBar()
+        configureCollectionView()
         bindToViewModel()
         fetchPlans()
     }
@@ -75,7 +81,11 @@ final class PlanListViewController: UIViewController {
                 title: StringLiteral.deleteActionTitle
             ) { _, _, _ in
                 do {
-                    try self.viewModel.deletePlan(at: indexPath)
+                    guard let id = self.dataSource.itemIdentifier(for: indexPath)
+                    else { return }
+
+                    let section = self.sectionIdentifiers[indexPath.section]
+                    try self.viewModel.deletePlan(in: section, id: id)
                 } catch let error {
                     self.presentErrorAlert(
                         title: CoreDataError.deleteFailure.localizedDescription,
@@ -94,7 +104,8 @@ final class PlanListViewController: UIViewController {
 
         let cellRegistration = UICollectionView
             .CellRegistration<PlanCollectionViewCell, ItemID> { cell, indexPath, identifier in
-                let viewModel = self.viewModel.item(at: indexPath, withID: identifier)
+                let section = self.sectionIdentifiers[indexPath.section]
+                let viewModel = self.viewModel.item(in: section, id: identifier)
                 cell.viewModel = viewModel
                 cell.checkBoxAction = UIAction { _ in
                     do {
@@ -123,7 +134,7 @@ final class PlanListViewController: UIViewController {
         let headerRegistration = UICollectionView.SupplementaryRegistration<DateCollectionHeaderView>(
             elementKind: StringLiteral.sectionHeaderElementKind
         ) { supplementaryView, _, indexPath in
-            supplementaryView.dateString = self.viewModel.title(forSection: indexPath.section)
+            supplementaryView.dateString = self.sectionIdentifiers[indexPath.section]
         }
 
         dataSource.supplementaryViewProvider = { collectionView, _, indexPath in
@@ -136,25 +147,23 @@ final class PlanListViewController: UIViewController {
         return dataSource
     }
 
-    private func applySnapshot() {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, ItemID>()
+    /// 새롭게 추가된 데이터만을 반영해서 스냅샷을 갱신
+    private func applySnapshot(usingData data: [(Section, ItemID)]) {
+        var snapshot = self.dataSource.snapshot()
 
-        viewModel.planViewModels.enumerated().forEach { section, items in
-            let itemIdentifiers = items.map { $0.id }
-            guard !itemIdentifiers.isEmpty
-            else {
-                return
+        data.forEach { section, itemID in
+            if !snapshot.sectionIdentifiers.contains(section) {
+                snapshot.appendSections([section])
             }
 
-            snapshot.appendSections([section])
-            snapshot.appendItems(itemIdentifiers, toSection: section)
+            snapshot.appendItems([itemID], toSection: section)
         }
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 
     private func fetchPlans() {
         do {
-            try viewModel.fetch()
+            try viewModel.fetchPlans()
         } catch let error {
             self.presentErrorAlert(
                 title: CoreDataError.fetchFailure.localizedDescription,
@@ -163,18 +172,28 @@ final class PlanListViewController: UIViewController {
         }
     }
 
+    private func configureCollectionView() {
+        collectionView.delegate = self
+    }
+
 
     // MARK: - ViewModel Configuration Functions
 
     private func bindToViewModel() {
-        viewModel.planFetchHandler = { [weak self] isEmpty in
-            self?.applySnapshot()
-            self?.collectionView.isEmpty = isEmpty
+        viewModel.planFetchHandler = { [weak self] in
+            self?.applySnapshot(usingData: $0)
+            self?.collectionView.isEmpty = self?.viewModel.planViewModels.isEmpty == true
         }
+
         viewModel.planDeleteHandler = { [weak self] in
             guard var snapshot = self?.dataSource.snapshot()
             else { return }
 
+            /// 섹션이 빈 경우 섹션도 삭제
+            if let section = snapshot.sectionIdentifier(containingItem: $0),
+               self?.viewModel.planViewModels[section] == nil {
+                snapshot.deleteSections([section])
+            }
             snapshot.deleteItems([$0])
             self?.dataSource.apply(snapshot, animatingDifferences: true)
             self?.collectionView.isEmpty = self?.viewModel.planViewModels.isEmpty == true
@@ -193,5 +212,17 @@ fileprivate extension PlanListViewController {
         static let sectionHeaderElementKind = "UICollectionElementKindSectionHeader"
 
         static let deleteActionTitle = "일정 삭제"
+    }
+}
+
+
+// MARK: - UICollectionViewDelegate 
+extension PlanListViewController: UICollectionViewDelegate {
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.didPassPoint()
+        else { return }
+
+        viewModel.userDidScrollToEnd()
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
@@ -8,22 +8,32 @@
 import Foundation
 
 final class PlanListViewModel {
+    typealias SectionAndPlanID = (section: String, planID: UUID)
 
     // MARK: - Properties
 
     let navigationTitle: String?
 
-    /// 일정 데이터를 성공적으로 받아왔을 때 호출하는 클로저
-    var planFetchHandler: ((Bool) -> Void)?
+    /// 새로운 일정 데이터가 추가되었을 때 호출하는 클로저
+    ///
+    /// 새로 추가된 일정의 ID와 섹션ID를 인자로 받음
+    var planFetchHandler: (([SectionAndPlanID]) -> Void)?
 
     /// 일정을 성공적으로 삭제했을 때 호출하는 클로저
+    ///
+    /// 삭제한 일정의 ID를 인자로 받음
     var planDeleteHandler: ((UUID) -> Void)?
 
-    private(set) var planViewModels = [[PlanViewModel]]()
-
+    private(set) var planViewModels = [String: [PlanViewModel]]()
+    
+    private let repository: PlanRepository
+    
     private let travelID: UUID
 
-    private let repository: PlanRepository
+    private var plans = [Plan]()
+
+    /// 아직 뷰모델로 변환되지 않은 Plan의 시작 인덱스
+    private var planOffset = Int.zero
 
     /// 22.11.16(수) 형태의 날짜를 리턴하는 DateFormatter
     private let sectionDateFormatter: DateFormatter = {
@@ -31,17 +41,6 @@ final class PlanListViewModel {
         formatter.dateFormat = StringLiteral.dateFormat
         return formatter
     }()
-
-    /// 현재 갖고 있는 일정 중 가장 오래된 날짜
-    private var lastSection: String? {
-        guard let plan = planViewModels.last?.last?.plan,
-              let date = plan.date
-        else {
-            return nil
-        }
-
-        return sectionDateFormatter.string(from: date)
-    }
 
     
     // MARK: - Init(s)
@@ -55,73 +54,79 @@ final class PlanListViewModel {
 
     // MARK: - Functions
 
-    func title(forSection section: Int) -> String? {
-        guard let plan = planViewModels[section].first?.plan,
-              let date = plan.date
-        else {
-            return nil
-        }
-
-        return sectionDateFormatter.string(from: date)
-    }
-
-    func item(at indexPath: IndexPath, withID id: UUID) -> PlanViewModel? {
-        // TODO: Safe Subscript -> 이 부분은 내일 대대적인 리팩토링이 있을 것 같아 일단 그냥 뒀습니다!
-        let item = planViewModels[indexPath.section][indexPath.row]
-        return item.id == id ? item : nil
+    func item(in section: String, id: UUID) -> PlanViewModel? {
+        planViewModels[section]?.first { $0.id == id }
     }
 
 
     // MARK: - Plan Fetching Functions
 
-    func fetch() throws {
-        let plans = try repository.fetchPlans(ofTravelID: travelID)
-        convertPlansToPlanViewModelsAndAppend(plans)
-        planFetchHandler?(planViewModels.isEmpty)
+    func fetchPlans() throws {
+        // TODO: 디바이스 별로 batchSize 계산하면 더 좋을듯?
+        plans = try repository.fetchPlans(ofTravelID: travelID, batchSize: Metric.batchSize)
+        let newSectionAndPlanID = convertPlansToPlanViewModelsAndAppend()
+        planFetchHandler?(newSectionAndPlanID)
     }
 
-    private func convertPlansToPlanViewModelsAndAppend(_ plans: [Plan]) {
-        plans.forEach {
-            guard let date = $0.date
+    /// 딕셔너리의 해당 Section키의 배열에 Plan을 PlanViewModel로 변환해서 추가한 후,
+    /// 추가한 PlanViewModel들을 섹션 정보와 함께 리턴
+    private func convertPlansToPlanViewModelsAndAppend() -> [SectionAndPlanID] {
+        var newSectionAndPlanID = [SectionAndPlanID]()
+
+        (Int.zero..<Metric.batchSize).forEach {
+            let index = planOffset + $0
+            guard plans.indices ~= index,
+                  let date = plans[index].date
             else {
                 return
             }
 
             let section = sectionDateFormatter.string(from: date)
-            let viewModel = PlanViewModel(plan: $0, repository: repository)
+            let viewModel = PlanViewModel(plan: plans[index], repository: repository)
 
-            if section == lastSection {
-                planViewModels[planViewModels.count - 1].append(viewModel)
-            } else {
-                planViewModels.append([viewModel])
-            }
+            planViewModels[section, default: []].append(viewModel)
+            newSectionAndPlanID.append((section, viewModel.id))
         }
+        planOffset += Metric.batchSize
+
+        return newSectionAndPlanID
     }
 
 
     // MARK: - Plan Deleting Functions
 
-    func deletePlan(at indexPath: IndexPath) throws {
-        let section = indexPath.section
-        let index = indexPath.row
+    func deletePlan(in section: String, id: UUID) throws {
+        guard let index = planViewModels[section]?.firstIndex(where: { $0.id == id }),
+              let planViewModel = planViewModels[section]?[index]
+        else {
+            return
+        }
 
-        guard section < planViewModels.count,
-              index < planViewModels[section].count
-        else { return }
-
-        let planViewModel = planViewModels[section][index]
         try repository.deletePlan(planViewModel.plan)
-        planViewModels[section].remove(at: index)
-        if planViewModels[section].isEmpty {
-            planViewModels.remove(at: section)
+        planViewModels[section]?.remove(at: index)
+
+        if planViewModels[section]?.isEmpty == true {
+            planViewModels[section] = nil
         }
         planDeleteHandler?(planViewModel.id)
+    }
+
+
+    // MARK: - Scroll Detecting Fucntions
+
+    func userDidScrollToEnd() {
+        let newSectionAndPlanID = convertPlansToPlanViewModelsAndAppend()
+        planFetchHandler?(newSectionAndPlanID)
     }
 }
 
 
 // MARK: - Constants
 fileprivate extension PlanListViewModel {
+
+    enum Metric {
+        static let batchSize = 20
+    }
 
     enum StringLiteral {
         static let dateFormat = "yy.MM.dd(E)"

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
@@ -21,7 +21,7 @@ final class PlanListViewModel {
 
     private(set) var planViewModels = [[PlanViewModel]]()
 
-    private let travel: Travel
+    private let travelID: UUID
 
     private let repository: PlanRepository
 
@@ -46,10 +46,10 @@ final class PlanListViewModel {
     
     // MARK: - Init(s)
 
-    init(travel: Travel, repository: PlanRepository) {
+    init(travelID: UUID, navgiationTitle: String, repository: PlanRepository) {
         self.repository = repository
-        self.travel = travel
-        self.navigationTitle = travel.name
+        self.travelID = travelID
+        self.navigationTitle = navgiationTitle
     }
 
 
@@ -75,7 +75,7 @@ final class PlanListViewModel {
     // MARK: - Plan Fetching Functions
 
     func fetch() throws {
-        let plans = try repository.fetchPlans(ofTravel: travel)
+        let plans = try repository.fetchPlans(ofTravelID: travelID)
         convertPlansToPlanViewModelsAndAppend(plans)
         planFetchHandler?(planViewModels.isEmpty)
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -199,7 +199,18 @@ extension TravelListViewController: TravelListViewModelDelegate {
 
 extension TravelListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // TODO: - 적당한 Plan으로 이동. 선택한 데이터의 UUID를 넘겨서 이동한 컨트롤러에서 데이터를 불러온다.
+        guard let travelViewModel = travelDataSource?.itemIdentifier(for: indexPath)
+        else {
+            return
+        }
+
+        let planListViewModel = PlanListViewModel(
+            travelID: travelViewModel.uuid,
+            navgiationTitle: travelViewModel.title,
+            repository: PlanLocalRepository()
+        )
+
+        show(PlanListViewController(viewModel: planListViewModel), sender: self)
     }
 }
 

--- a/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanLocalRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanLocalRepository.swift
@@ -17,9 +17,9 @@ struct PlanLocalRepository: PlanRepository {
 
     // MARK: - CRUD Functions
 
-    func fetchPlans(ofTravelID id: UUID) throws -> [Plan] {
+    func fetchPlans(ofTravelID id: UUID, batchSize: Int) throws -> [Plan] {
         let request = Plan.fetchRequest(travelID: id)
-
+        request.fetchBatchSize = batchSize
         // TODO: 코어데이터 메서드 바꾸자고 하기(에러 던지는 방식으로)
         return persistentManager.fetch(request: request)
     }

--- a/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanLocalRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanLocalRepository.swift
@@ -17,8 +17,8 @@ struct PlanLocalRepository: PlanRepository {
 
     // MARK: - CRUD Functions
 
-    func fetchPlans(ofTravel travel: Travel) throws -> [Plan] {
-        let request = Plan.fetchRequest(travel: travel)
+    func fetchPlans(ofTravelID id: UUID) throws -> [Plan] {
+        let request = Plan.fetchRequest(travelID: id)
 
         // TODO: 코어데이터 메서드 바꾸자고 하기(에러 던지는 방식으로)
         return persistentManager.fetch(request: request)

--- a/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Plan 엔티티에 대한 CRUD 작업을 수행하는 저장소
 protocol PlanRepository {
 
-    func fetchPlans(ofTravel travel: Travel) throws -> [Plan]
+    func fetchPlans(ofTravelID id: UUID) throws -> [Plan]
 
     func save() throws
 

--- a/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/PlanList/PlanRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 /// Plan 엔티티에 대한 CRUD 작업을 수행하는 저장소
 protocol PlanRepository {
 
-    func fetchPlans(ofTravelID id: UUID) throws -> [Plan]
+    func fetchPlans(ofTravelID id: UUID, batchSize: Int) throws -> [Plan]
 
     func save() throws
 

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIScrollView+DidPassPoint.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIScrollView+DidPassPoint.swift
@@ -1,0 +1,20 @@
+//
+//  UIScrollView+DidPassPoint.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/17.
+//
+
+import UIKit
+
+extension UIScrollView {
+
+    /// 현재 스크롤 위치가 contentsize * 인자로 주어진 값을 곱한 높이를 초과하면 true, 아니면 false
+    func didPassPoint(ofContentSizeRatio ratio: CGFloat = 0.8) -> Bool {
+        let offsetY = contentOffset.y
+        let targetPoint = (contentSize.height - frame.height) * ratio
+        let didPassTarget = offsetY > targetPoint
+
+        return didPassTarget
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIViewController+SetRightBarPlusButton.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIViewController+SetRightBarPlusButton.swift
@@ -1,0 +1,23 @@
+//
+//  UIViewController+SetRightBarPlusButton.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/16.
+//
+
+import UIKit
+
+extension UIViewController {
+
+    /// 누르면 항목을 추가할 수 있는 뷰를 띄우는 우측 내비게이션 바 버튼을 설정
+    ///
+    /// 제목은 없고 + 아이콘만 가짐
+    /// - Parameter viewController: 추가 버튼을 누르면 띄울 뷰 컨트롤러
+    func setRightBarAddButton(showing viewController: UIViewController) {
+        let addButton = UIBarButtonItem(systemItem: .add, primaryAction: UIAction(handler: { _ in
+            self.show(viewController, sender: self)
+        }))
+        addButton.tintColor = .black
+        navigationItem.setRightBarButton(addButton, animated: true)
+    }
+}

--- a/Doesaegim/NSManagedObjectClass/Plan+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Plan+CoreDataClass.swift
@@ -45,11 +45,10 @@ public class Plan: NSManagedObject {
 
     /// 특정 Travel 엔티티의 모든 Plan을 호출하는 리퀘스트로 순서를 지정하지 않으면 (오래된) 날짜 순서로 정렬
     static func fetchRequest(
-        travel: Travel,
+        travelID: UUID,
         sortDescriptors: [NSSortDescriptor] = [.init(key: "date", ascending: false)]
     ) -> NSFetchRequest<Plan> {
-
-        let predicate = NSPredicate(format: "travel == %@", argumentArray: [travel])
+        let predicate = NSPredicate(format: "travel.id == %@", argumentArray: [travelID])
         return fetchRequest(predicate: predicate, sortDescriptors: sortDescriptors)
     }
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- resolves #13, #15
- 일정 추가 화면이랑 연결하는 김에 여행 목록에서 넘어오는 것도 연결했습니다. 
- 코어데이터 호출 방식과 스냅샷 방식을 변경했습니다. 

<br>

## 리뷰노트
> 고민, 과정, 궁금한점

- 데이터가 많을 경우를 대비해 코어데이터를 활용하는 방식을 변경했습니다. 
  - 코어데이터에 fetchRequest를 날릴 때 fetchBatchSize를 화면 크기만큼의 일정 개수로 설정해서 일정은 한 번에 모두 가져오되 실제 메모리에 올리는 건 유저의 스크롤 정도에 따라 필요한 만큼만 올리도록 했습니다. 
   - 관련해서 스냅샷도 새로 추가된 일정에 관한 데이터만 매번 갱신하는 방식으로 변경했습니다. 
   - 좀 더 자세한 설명을 위해 오늘 [기술 공유 발표 자료 링크](https://docs.google.com/presentation/d/1uIOf-sDcI7cQ3BYTGM6BYKKsZm7Wjw0M5hpVmQ80tiE/edit?usp=sharing)를 같이 첨부합니다, 제 나름대로 왜 이런식으로 했는지, 어떤 문제를 겪었는지 슬라이드마다 아래 주석 칸에 설명으로 달아놨습니다! 주말이 끝나기 전에 해당 주제로 기술 포스팅...도 쓰는 게 목표인데 쓰는대로 공유하겠습니다...!

<br>

## 스크린샷

![Simulator Screen Recording - iPhone 14 - 2022-11-18 at 20 38 44](https://user-images.githubusercontent.com/81314063/202697010-d7437475-ce09-4743-bc0e-06e5cfe577c5.gif)

