### PR TITLE
[여행 목록, 지출 여행목록, 지출 목록] 커스텀 셀 생성, 스타일, 헤더등록

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
 		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
 		BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */; };
+		BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */; };
+		BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A3F2926008D00C9E3A9 /* ExpenseListViewModel.swift */; };
 		BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */; };
 		BBD0D05D291DE975007D0D82 /* ExpenseTravelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */; };
 		BBD0D05F291DE97F007D0D82 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05E291DE97F007D0D82 /* MapViewController.swift */; };
@@ -132,6 +134,8 @@
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
 		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListCell.swift; sourceTree = "<group>"; };
+		BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewController.swift; sourceTree = "<group>"; };
+		BBB31A3F2926008D00C9E3A9 /* ExpenseListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewModel.swift; sourceTree = "<group>"; };
 		BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewController.swift; sourceTree = "<group>"; };
 		BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListController.swift; sourceTree = "<group>"; };
 		BBD0D05E291DE97F007D0D82 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -216,6 +220,7 @@
 			isa = PBXGroup;
 			children = (
 				BB57719E29239E9F0034047D /* ExpenseTravelList */,
+				BBB31A3A2926003700C9E3A9 /* ExpenseList */,
 			);
 			path = ExpenseScene;
 			sourceTree = "<group>";
@@ -416,6 +421,31 @@
 			isa = PBXGroup;
 			children = (
 				BBE695D529227C8D0015FAD4 /* TravelInfoViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		BBB31A3A2926003700C9E3A9 /* ExpenseList */ = {
+			isa = PBXGroup;
+			children = (
+				BBB31A3C2926005F00C9E3A9 /* ViewModel */,
+				BBB31A3B2926005B00C9E3A9 /* View */,
+			);
+			path = ExpenseList;
+			sourceTree = "<group>";
+		};
+		BBB31A3B2926005B00C9E3A9 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		BBB31A3C2926005F00C9E3A9 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BBB31A3F2926008D00C9E3A9 /* ExpenseListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -807,7 +837,9 @@
 				A4CC04C929227C7200BB678B /* PlanCollectionViewCell.swift in Sources */,
 				A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */,
 				A48E9946292512BC0029D57D /* CoreDataError.swift in Sources */,
+				BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */,
 				BBD0D066291DED6A007D0D82 /* UIColor+.swift in Sources */,
+				BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */,
 				A4CC04C429226FC100BB678B /* String+Placeholders.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -26,11 +26,11 @@
 		A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D0292324B000BB678B /* EmptyLabeledCollectionView.swift */; };
 		A4CC04D32923308600BB678B /* DateCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D22923308600BB678B /* DateCollectionHeaderView.swift */; };
 		A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D4292332C600BB678B /* UILabel+ChangeFontSize.swift */; };
+		A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D62923347E00BB678B /* PlanListViewController.swift */; };
 		A4CC04D9292351D700BB678B /* PlanRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D8292351D700BB678B /* PlanRepository.swift */; };
+		A4CC04DE2923543500BB678B /* PlanListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04DD2923543500BB678B /* PlanListViewModel.swift */; };
 		A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04DF2923738500BB678B /* PlanLocalRepository.swift */; };
 		A4CC04E22923777B00BB678B /* NSObject+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04E12923777B00BB678B /* NSObject+Name.swift */; };
-		A4CC04DE2923543500BB678B /* PlanListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04DD2923543500BB678B /* PlanListViewModel.swift */; };
-		A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4CC04D62923347E00BB678B /* PlanListViewController.swift */; };
 		B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D96252922301E00B510B8 /* TravelDTO.swift */; };
 		B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D9627292230CA00B510B8 /* PlanDTO.swift */; };
 		B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962B2922315500B510B8 /* LocationDTO.swift */; };
@@ -44,6 +44,7 @@
 		B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */; };
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
+		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
 		BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */; };
 		BBD0D05D291DE975007D0D82 /* ExpenseTravelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */; };
 		BBD0D05F291DE97F007D0D82 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05E291DE97F007D0D82 /* MapViewController.swift */; };
@@ -110,11 +111,11 @@
 		A4CC04D0292324B000BB678B /* EmptyLabeledCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyLabeledCollectionView.swift; sourceTree = "<group>"; };
 		A4CC04D22923308600BB678B /* DateCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateCollectionHeaderView.swift; sourceTree = "<group>"; };
 		A4CC04D4292332C600BB678B /* UILabel+ChangeFontSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+ChangeFontSize.swift"; sourceTree = "<group>"; };
+		A4CC04D62923347E00BB678B /* PlanListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewController.swift; sourceTree = "<group>"; };
 		A4CC04D8292351D700BB678B /* PlanRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanRepository.swift; sourceTree = "<group>"; };
+		A4CC04DD2923543500BB678B /* PlanListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewModel.swift; sourceTree = "<group>"; };
 		A4CC04DF2923738500BB678B /* PlanLocalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanLocalRepository.swift; sourceTree = "<group>"; };
 		A4CC04E12923777B00BB678B /* NSObject+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Name.swift"; sourceTree = "<group>"; };
-		A4CC04DD2923543500BB678B /* PlanListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewModel.swift; sourceTree = "<group>"; };
-		A4CC04D62923347E00BB678B /* PlanListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewController.swift; sourceTree = "<group>"; };
 		B57D96252922301E00B510B8 /* TravelDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDTO.swift; sourceTree = "<group>"; };
 		B57D9627292230CA00B510B8 /* PlanDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDTO.swift; sourceTree = "<group>"; };
 		B57D962B2922315500B510B8 /* LocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDTO.swift; sourceTree = "<group>"; };
@@ -128,6 +129,7 @@
 		B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewModelDelegate.swift; sourceTree = "<group>"; };
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
+		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
 		BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewController.swift; sourceTree = "<group>"; };
 		BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListController.swift; sourceTree = "<group>"; };
 		BBD0D05E291DE97F007D0D82 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 			isa = PBXGroup;
 			children = (
 				BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */,
+				BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -763,6 +766,7 @@
 				A4CC04CD2922818900BB678B /* UIView+AddSubviews.swift in Sources */,
 				BBFAC091291CBDD700D7FD57 /* Doesaegim.xcdatamodeld in Sources */,
 				A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */,
+				BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */,
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
@@ -777,7 +781,6 @@
 				B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */,
 				BBE695DA29228C570015FAD4 /* TravelListViewModelProtocol.swift in Sources */,
 				B5C096C029236BC0007426B1 /* SearchResultCellViewModel.swift in Sources */,
-				BBE695D4292273A10015FAD4 /* TravelCollectionViewCell.swift in Sources */,
 				A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */,
 				A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */,
 				B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -56,6 +56,9 @@
 		BBD0D061291DE988007D0D82 /* DiaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D060291DE988007D0D82 /* DiaryViewController.swift */; };
 		BBD0D063291DE991007D0D82 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D062291DE991007D0D82 /* SettingViewController.swift */; };
 		BBD0D066291DED6A007D0D82 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D065291DED6A007D0D82 /* UIColor+.swift */; };
+		BBDB2E922926222100752924 /* ExpenseInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDB2E912926222100752924 /* ExpenseInfoViewModel.swift */; };
+		BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDB2E9329262BB300752924 /* ExpenseCollectionHeaderView.swift */; };
+		BBDB2E96292635FD00752924 /* ExpenseSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDB2E95292635FD00752924 /* ExpenseSectionHeaderView.swift */; };
 		BBE695D629227C8D0015FAD4 /* TravelInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE695D529227C8D0015FAD4 /* TravelInfoViewModel.swift */; };
 		BBE695D829228B560015FAD4 /* TravelListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE695D729228B560015FAD4 /* TravelListViewModel.swift */; };
 		BBE695DA29228C570015FAD4 /* TravelListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE695D929228C570015FAD4 /* TravelListViewModelProtocol.swift */; };
@@ -146,6 +149,9 @@
 		BBD0D060291DE988007D0D82 /* DiaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryViewController.swift; sourceTree = "<group>"; };
 		BBD0D062291DE991007D0D82 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		BBD0D065291DED6A007D0D82 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		BBDB2E912926222100752924 /* ExpenseInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseInfoViewModel.swift; sourceTree = "<group>"; };
+		BBDB2E9329262BB300752924 /* ExpenseCollectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseCollectionHeaderView.swift; sourceTree = "<group>"; };
+		BBDB2E95292635FD00752924 /* ExpenseSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseSectionHeaderView.swift; sourceTree = "<group>"; };
 		BBE695D529227C8D0015FAD4 /* TravelInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelInfoViewModel.swift; sourceTree = "<group>"; };
 		BBE695D729228B560015FAD4 /* TravelListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewModel.swift; sourceTree = "<group>"; };
 		BBE695D929228C570015FAD4 /* TravelListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -425,6 +431,7 @@
 			isa = PBXGroup;
 			children = (
 				BBE695D529227C8D0015FAD4 /* TravelInfoViewModel.swift */,
+				BBDB2E912926222100752924 /* ExpenseInfoViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -444,6 +451,8 @@
 				BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */,
 				BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */,
 				BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */,
+				BBDB2E9329262BB300752924 /* ExpenseCollectionHeaderView.swift */,
+				BBDB2E95292635FD00752924 /* ExpenseSectionHeaderView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -797,6 +806,7 @@
 				B5C096C429238091007426B1 /* SearchingLocationViewModel.swift in Sources */,
 				A4CC04A429221EEE00BB678B /* Plan+CoreDataClass.swift in Sources */,
 				EE116C5E2924CB6B0017B519 /* TravelAddViewProtocol.swift in Sources */,
+				BBDB2E96292635FD00752924 /* ExpenseSectionHeaderView.swift in Sources */,
 				EE3E29BC2923C870007C7FC7 /* TravelAddViewController.swift in Sources */,
 				BBD0D063291DE991007D0D82 /* SettingViewController.swift in Sources */,
 				A4CC04D32923308600BB678B /* DateCollectionHeaderView.swift in Sources */,
@@ -805,6 +815,7 @@
 				A4CC04CD2922818900BB678B /* UIView+AddSubviews.swift in Sources */,
 				BBFAC091291CBDD700D7FD57 /* Doesaegim.xcdatamodeld in Sources */,
 				A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */,
+				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
 				BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */,
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
@@ -823,6 +834,7 @@
 				A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */,
 				A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */,
 				B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */,
+				BBDB2E922926222100752924 /* ExpenseInfoViewModel.swift in Sources */,
 				BBE695D629227C8D0015FAD4 /* TravelInfoViewModel.swift in Sources */,
 				A4CC04A829221EEE00BB678B /* Expense+CoreDataClass.swift in Sources */,
 				A4CC04E22923777B00BB678B /* NSObject+Name.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
 		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
+		BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */; };
 		BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */; };
 		BBD0D05D291DE975007D0D82 /* ExpenseTravelListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */; };
 		BBD0D05F291DE97F007D0D82 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD0D05E291DE97F007D0D82 /* MapViewController.swift */; };
@@ -130,6 +131,7 @@
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
 		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
+		BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListCell.swift; sourceTree = "<group>"; };
 		BBD0D05A291DE956007D0D82 /* TravelListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewController.swift; sourceTree = "<group>"; };
 		BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListController.swift; sourceTree = "<group>"; };
 		BBD0D05E291DE97F007D0D82 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				BBD0D05C291DE975007D0D82 /* ExpenseTravelListController.swift */,
+				BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -792,6 +795,7 @@
 				A4CC04DE2923543500BB678B /* PlanListViewModel.swift in Sources */,
 				BBD0D061291DE988007D0D82 /* DiaryViewController.swift in Sources */,
 				EE116C582924AA0D0017B519 /* CustomCalendarCell.swift in Sources */,
+				BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */,
 				B57D962E2922318F00B510B8 /* ExpenseDTO.swift in Sources */,
 				B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */,
 				BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
 		BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */; };
+		BB7D9A2A29261C0600BF2BD6 /* ExpenseListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */; };
 		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
 		BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */; };
 		BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */; };
@@ -134,6 +135,7 @@
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
 		BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpensePlaceholdView.swift; sourceTree = "<group>"; };
+		BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListCell.swift; sourceTree = "<group>"; };
 		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewController.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 			children = (
 				BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */,
 				BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */,
+				BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -838,6 +841,7 @@
 				EE116C5A2924AA0D0017B519 /* CustomCalendar.swift in Sources */,
 				EE3E29A829235F6B007C7FC7 /* UITextField+.swift in Sources */,
 				A4CC04822922191300BB678B /* PersistentManager.swift in Sources */,
+				BB7D9A2A29261C0600BF2BD6 /* ExpenseListCell.swift in Sources */,
 				A4CC04C929227C7200BB678B /* PlanCollectionViewCell.swift in Sources */,
 				A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */,
 				A48E9946292512BC0029D57D /* CoreDataError.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */; };
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
+		BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */; };
 		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
 		BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */; };
 		BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */; };
@@ -132,6 +133,7 @@
 		B5C096C529238A0B007426B1 /* SearchingLocationViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewModelDelegate.swift; sourceTree = "<group>"; };
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
+		BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpensePlaceholdView.swift; sourceTree = "<group>"; };
 		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewController.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 			isa = PBXGroup;
 			children = (
 				BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */,
+				BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -828,6 +831,7 @@
 				BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */,
 				B57D962E2922318F00B510B8 /* ExpenseDTO.swift in Sources */,
 				B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */,
+				BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */,
 				BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */,
 				EE116C592924AA0D0017B519 /* CustomCalendarHeaderView.swift in Sources */,
 				A4CC04A229221EEE00BB678B /* Diary+CoreDataClass.swift in Sources */,

--- a/Doesaegim/Doesaegim/Data/ViewModel/ExpenseInfoViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/ExpenseInfoViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  ExpenseInfoViewModel.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import Foundation
+
+struct ExpenseInfoViewModel: Hashable {
+    
+    // TODO: - 카테고리 더 생각해보기...일단 식비로 다 몰아버렷
+    enum ExpenseCategory {
+        case food
+    }
+    
+    var uuid: UUID // 뺄수있다면 뺀다. -> hash 메서드때문에 못빼려나...?
+    var name: String
+    var cost: Int
+    var content: String
+    var date: Date
+    
+    init(uuid: UUID, name: String, content: String, cost: Int, date: Date) {
+        self.uuid = uuid
+        self.name = name
+        self.content = content
+        self.cost = cost
+        self.date = date
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
+    }
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
@@ -8,5 +8,19 @@
 import UIKit
 
 final class ExpenseCollectionHeaderView: UICollectionReusableView {
-        
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func configure() {
+        backgroundColor = .blue
+    }
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
@@ -1,0 +1,12 @@
+//
+//  ExpenseCollectionHeaderView.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+final class ExpenseCollectionHeaderView: UICollectionReusableView {
+        
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
@@ -23,4 +23,8 @@ final class ExpenseCollectionHeaderView: UICollectionReusableView {
         backgroundColor = .blue
     }
     
+    func configureData() {
+        print(#function)
+    }
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class ExpenseListCell: UICollectionViewListCell {
     
+    static let identifier: String = "\(String(describing: ExpenseListCell.self))"
+    
     // MARK: - Properties
     
     let priceLabel: UILabel = {

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -1,0 +1,12 @@
+//
+//  ExpenseListCell.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+final class ExpenseListCell: UICollectionViewListCell {
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -9,4 +9,53 @@ import UIKit
 
 final class ExpenseListCell: UICollectionViewListCell {
     
+    // MARK: - Properties
+    
+    let priceLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .systemRed
+        label.font = label.font.withSize(12)
+        
+        return label
+
+    }()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Configuration
+    
+    private func configure() {
+        configureSubviews()
+        configureConstraints()
+    }
+    
+    private func configureSubviews() {
+        addSubview(priceLabel)
+    }
+    
+    private func configureConstraints() {
+        priceLabel.snp.makeConstraints {
+            $0.centerY.equalTo(self.snp.centerY)
+            $0.trailing.equalTo(self.snp.trailing).offset(-12)
+        }
+    }
+    
+    func configureContent() {
+        
+    }
+    
+//    private func createContentConfiguration() -> UIContentConfiguration {
+//
+//    }
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -96,11 +96,11 @@ final class ExpenseListViewController: UIViewController {
         )
         
         // 섹션 헤더 등록
-        expenseCollectionView.register(
-            ExpenseSectionHeaderView.self,
-            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-            withReuseIdentifier: ExpenseSectionHeaderView.identifier
-        )
+//        expenseCollectionView.register(
+//            ExpenseSectionHeaderView.self,
+//            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+//            withReuseIdentifier: ExpenseSectionHeaderView.identifier
+//        )
         
         
     }
@@ -135,6 +135,7 @@ final class ExpenseListViewController: UIViewController {
         configuration.boundarySupplementaryItems = [globalHeader]
         
         return configuration
+        
     }
     
     private func configureCollectionViewDataSource() {
@@ -162,7 +163,8 @@ final class ExpenseListViewController: UIViewController {
             supplementaryView.configureData()
         }
         
-        let sectionHeaderRgistration = SectionHeaderRegistration(
+        // TODO: - section Header 타이틀 바꾸기
+        let sectionHeaderRegistration = SectionHeaderRegistration(
             elementKind: HeaderKind.sectionHeader
         ) { supplementaryView, _, _ in
             supplementaryView.configureData(dateString: "날짜입니다.")
@@ -175,9 +177,9 @@ final class ExpenseListViewController: UIViewController {
                     for: indexPath
                 )
             }
-            
+
             return self?.expenseCollectionView.dequeueConfiguredReusableSupplementary(
-                using: sectionHeaderRgistration,
+                using: sectionHeaderRegistration,
                 for: indexPath
             )
         }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -21,8 +21,8 @@ class ExpenseListViewController: UIViewController {
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         // TODO: - cornerRadius 적용되지 않는 것 고민
-        collectionView.backgroundColor = .blue
-        collectionView.layer.cornerRadius = 7
+        collectionView.backgroundColor = .white
+        collectionView.layer.cornerRadius = 12
         return collectionView
     }()
     
@@ -53,7 +53,7 @@ class ExpenseListViewController: UIViewController {
     
     private func configureConstraints() {
         expenseCollectionView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
             $0.verticalEdges.equalTo(view.safeAreaLayoutGuide)
         }
         
@@ -62,7 +62,7 @@ class ExpenseListViewController: UIViewController {
             $0.centerX.equalTo(view.snp.centerX)
             $0.centerY.equalTo(view.snp.centerY)
             $0.width.equalTo(view.bounds.width - 100)
-            $0.height.equalTo(60)
+            $0.height.equalTo(50)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ExpenseListViewController: UIViewController {
+final class ExpenseListViewController: UIViewController {
 
     // MARK: - Properties
     
@@ -36,7 +36,6 @@ class ExpenseListViewController: UIViewController {
         configureNavigationBar()
         configureSubviews()
         configureConstraints()
-
     }
     
     // MARK: - Configuration
@@ -44,6 +43,12 @@ class ExpenseListViewController: UIViewController {
     private func configureNavigationBar() {
         // TODO: - 여행 이름도 네비게이션 타이틀에 포함하기 "(여행이름) - 지출내역"
         navigationItem.title = "지출 내역"
+        navigationController?.navigationBar.tintColor = .primaryOrange
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .add,
+            target: self,
+            action: #selector(didAddExpenseButtonTap)
+        )
     }
     
     private func configureSubviews() {
@@ -60,7 +65,7 @@ class ExpenseListViewController: UIViewController {
         placeholdView.snp.makeConstraints {
             // TODO: - 뷰의 위치 추후 다시 설정
             $0.centerX.equalTo(view.snp.centerX)
-            $0.centerY.equalTo(view.snp.centerY)
+            $0.centerY.equalTo(view.snp.centerY).multipliedBy(1.3)
             $0.width.equalTo(view.bounds.width - 100)
             $0.height.equalTo(50)
         }
@@ -68,4 +73,11 @@ class ExpenseListViewController: UIViewController {
     
     // MARK: - Collection View
     
+    
+    // MARK: - Action
+    
+    @objc func didAddExpenseButtonTap() {
+        // TODO: - 지출 추가 화면으로 이동
+        print("지출 추가버튼이 탭 되었습니다.")
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -9,21 +9,54 @@ import UIKit
 
 class ExpenseListViewController: UIViewController {
 
+    // MARK: - Properties
+    
+    
+    let expenseCollectionView: UICollectionView = {
+        var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        configuration.showsSeparators = true
+//        configuration.trailingSwipeActionsConfigurationProvider
+        let layout = UICollectionViewCompositionalLayout.list(using: configuration)
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        // TODO: - cornerRadius 적용되지 않는 것 고민
+        collectionView.backgroundColor = .blue
+        collectionView.layer.cornerRadius = 7
+        return collectionView
+    }()
+    
+    var travelID: UUID? // 여행목록에서 선택한 여행의 ID. 지출목록을 가져오는데에 사용한다.
+    
+    // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureNavigationBar()
+        configureSubviews()
+        configureConstraints()
 
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    // MARK: - Configuration
+    
+    private func configureNavigationBar() {
+        // TODO: - 여행 이름도 네비게이션 타이틀에 포함하기 "(여행이름) - 지출내역"
+        navigationItem.title = "지출 내역"
     }
-    */
-
+    
+    private func configureSubviews() {
+        view.addSubview(expenseCollectionView)
+//        view.addSubview(placeholdLabel)
+    }
+    
+    private func configureConstraints() {
+        expenseCollectionView.snp.makeConstraints {
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
+            $0.verticalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    // MARK: - Collection View
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -11,6 +11,7 @@ class ExpenseListViewController: UIViewController {
 
     // MARK: - Properties
     
+    let placeholdView: ExpensePlaceholdView = ExpensePlaceholdView()
     
     let expenseCollectionView: UICollectionView = {
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
@@ -47,13 +48,21 @@ class ExpenseListViewController: UIViewController {
     
     private func configureSubviews() {
         view.addSubview(expenseCollectionView)
-//        view.addSubview(placeholdLabel)
+        view.addSubview(placeholdView)
     }
     
     private func configureConstraints() {
         expenseCollectionView.snp.makeConstraints {
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
             $0.verticalEdges.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        placeholdView.snp.makeConstraints {
+            // TODO: - 뷰의 위치 추후 다시 설정
+            $0.centerX.equalTo(view.snp.centerX)
+            $0.centerY.equalTo(view.snp.centerY)
+            $0.width.equalTo(view.bounds.width - 100)
+            $0.height.equalTo(60)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -112,10 +112,10 @@ final class ExpenseListViewController: UIViewController {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(200)
         )
-        let sectionHeaderSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(40)
-        )
+//        let sectionHeaderSize = NSCollectionLayoutSize(
+//            widthDimension: .fractionalWidth(1.0),
+//            heightDimension: .absolute(40)
+//        )
         
         let globalHeader = NSCollectionLayoutBoundarySupplementaryItem(
             layoutSize: globalHeaderSize,
@@ -124,15 +124,15 @@ final class ExpenseListViewController: UIViewController {
         )
         globalHeader.pinToVisibleBounds = true
         
-        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
-            layoutSize: sectionHeaderSize,
-            elementKind: HeaderKind.sectionHeader,
-            alignment: .top
-        )
+//        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
+//            layoutSize: sectionHeaderSize,
+//            elementKind: HeaderKind.sectionHeader,
+//            alignment: .top
+//        )
         
         let configuration = UICollectionViewCompositionalLayoutConfiguration()
         configuration.interSectionSpacing = 20
-        configuration.boundarySupplementaryItems = [globalHeader, sectionHeader]
+        configuration.boundarySupplementaryItems = [globalHeader]
         
         return configuration
     }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ExpenseListViewController.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+class ExpenseListViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -110,7 +110,7 @@ final class ExpenseListViewController: UIViewController {
     private func createLayoutConfiguration() ->  UICollectionViewCompositionalLayoutConfiguration {
         let globalHeaderSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
-            heightDimension: .absolute(100)
+            heightDimension: .absolute(200)
         )
         let sectionHeaderSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
@@ -5,8 +5,54 @@
 //  Created by Jaehoon So on 2022/11/17.
 //
 
-import Foundation
+import UIKit
 
 final class ExpensePlaceholdView: UIView {
     
+    // MARK: - Properties
+    
+    let mainLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .primaryOrange
+        label.text = "지출 내역이 없어요!"
+        
+        return label
+    }()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Configuration
+    
+    private func configure() {
+        configureSubviews()
+        configureStyle()
+        configureContstraints()
+    }
+    
+    private func configureSubviews() {
+        addSubview(mainLabel)
+    }
+    
+    private func configureStyle() {
+        layer.cornerRadius = 7
+        layer.borderColor = UIColor.primaryOrange?.cgColor
+        layer.borderWidth = 1
+    }
+    
+    private func configureContstraints() {
+        mainLabel.snp.makeConstraints {
+            $0.centerX.equalTo(self.snp.centerX)
+            $0.centerY.equalTo(self.snp.centerX)
+        }
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
@@ -44,6 +44,7 @@ final class ExpensePlaceholdView: UIView {
     }
     
     private func configureStyle() {
+        backgroundColor = .white
         layer.cornerRadius = 7
         layer.borderColor = UIColor.primaryOrange?.cgColor
         layer.borderWidth = 1
@@ -52,7 +53,7 @@ final class ExpensePlaceholdView: UIView {
     private func configureContstraints() {
         mainLabel.snp.makeConstraints {
             $0.centerX.equalTo(self.snp.centerX)
-            $0.centerY.equalTo(self.snp.centerX)
+            $0.centerY.equalTo(self.snp.centerY)
         }
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
@@ -1,0 +1,12 @@
+//
+//  ExpensePlaceholdView.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import Foundation
+
+final class ExpensePlaceholdView: UIView {
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -1,0 +1,48 @@
+//
+//  ExpenseSectionHeader.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+final class ExpenseSectionHeaderView: UICollectionReusableView {
+    
+    static let identifier: String = String(describing: ExpenseSectionHeaderView.self)
+    
+    let dateLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 20)
+        label.text = "날짜날짜"
+        label.textColor = .black
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func configure() {
+        configureSubviews()
+        configureConstraints()
+    }
+    
+    private func configureSubviews() {
+        addSubview(dateLabel)
+    }
+    
+    private func configureConstraints() {
+        dateLabel.snp.makeConstraints {
+            $0.centerY.equalTo(self.snp.centerY)
+            $0.leading.equalTo(self.snp.leading)
+        }
+    }
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -31,6 +31,7 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     }
     
     private func configure() {
+        backgroundColor = .red
         configureSubviews()
         configureConstraints()
     }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -13,7 +13,7 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     
     let dateLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.boldSystemFont(ofSize: 20)
+        label.font = UIFont.boldSystemFont(ofSize: 16)
         label.text = "날짜날짜"
         label.textColor = .black
         
@@ -44,5 +44,9 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
             $0.centerY.equalTo(self.snp.centerY)
             $0.leading.equalTo(self.snp.leading)
         }
+    }
+    
+    func configureData(dateString: String) {
+        dateLabel.text = dateString
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  ExpenseListViewModel.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import Foundation

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
@@ -9,4 +9,77 @@ import UIKit
 
 final class ExpenseTravelListCell: UICollectionViewListCell {
     
+    // MARK: - Properties
+    
+    let priceLabel: UILabel = {
+        let label = UILabel()
+        label.text = "000,000원"
+        label.textColor = .grey4
+        label.font = label.font.withSize(12)
+        
+        return label
+    }()
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureCell()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Configuration
+    
+    private func configureCell() {
+        configureSubviews()
+        configureConstraint()
+    }
+    
+    private func configureSubviews() {
+        addSubview(priceLabel)
+    }
+    
+    private func configureConstraint() {
+        priceLabel.snp.makeConstraints {
+            $0.centerY.equalTo(self.snp.centerY)
+            $0.trailing.equalTo(self.snp.trailing).offset(-6)
+        }
+    }
+    
+    func configureContent(with identifier: TravelInfoViewModel) {
+        
+        contentConfiguration = createContentConfiguration(of: identifier)
+    }
+    
+    private func createContentConfiguration(of identifier: TravelInfoViewModel) -> UIListContentConfiguration {
+        
+        var configuration = defaultContentConfiguration()
+        configuration.image = UIImage(systemName: "airplane.departure")
+        configuration.imageProperties.tintColor = .primaryOrange
+        configuration.attributedText = NSAttributedString(
+            string: identifier.title,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 18),
+                .foregroundColor: UIColor.black!
+            ]
+        )
+        configuration.secondaryAttributedText = NSAttributedString(
+            string: Date.convertTravelString(
+                start: identifier.startDate,
+                end: identifier.endDate
+            ),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 12),
+                .foregroundColor: UIColor.grey4!
+                    
+            ]
+        )
+        
+        return configuration
+    }
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
@@ -1,0 +1,12 @@
+//
+//  ExpenseTravelListCell.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+final class ExpenseTravelListCell: UICollectionViewListCell {
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
@@ -46,7 +46,7 @@ final class ExpenseTravelListCell: UICollectionViewListCell {
     private func configureConstraint() {
         priceLabel.snp.makeConstraints {
             $0.centerY.equalTo(self.snp.centerY)
-            $0.trailing.equalTo(self.snp.trailing).offset(-6)
+            $0.trailing.equalTo(self.snp.trailing).offset(-12)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -36,6 +36,8 @@ final class ExpenseTravelListController: UIViewController {
     
     var travelDataSource: DataSource?
     
+    var selectedID: UUID?
+    
     var viewModel: ExpenseTravelViewModelProtocol? = ExpenseTravelViewModel()
     
     // MARK: - Life Cycle
@@ -45,6 +47,7 @@ final class ExpenseTravelListController: UIViewController {
         view.backgroundColor = .white
         
         viewModel?.delegate = self
+        collectionView.delegate = self
         
         configureNavigationBar()
         configureSubviews()
@@ -77,6 +80,19 @@ final class ExpenseTravelListController: UIViewController {
         collectionView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
             $0.verticalEdges.equalToSuperview().inset(0)
+        }
+    }
+    
+    // MARK: - Navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let destinationViewController = segue.destination
+        
+        switch destinationViewController {
+        case let viewController as ExpenseListViewController:
+            print("ExpenseListViewcontroller로 이동합니다.")
+            viewController.travelID = selectedID
+        default:
+            print("잘못된 접근입니다.")
         }
     }
     
@@ -118,6 +134,18 @@ final class ExpenseTravelListController: UIViewController {
         )   
     }
 }
+
+// MARK: - UICollectionViewDelegate
+
+extension ExpenseTravelListController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let viewModel = viewModel else { return }
+        
+        selectedID = viewModel.travelInfos[indexPath.row].uuid
+        navigationController?.pushViewController(ExpenseListViewController(), animated: true)
+    }
+}
+
 
 // MARK: - ExpenseTravelViewModelDelegate
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -13,7 +13,7 @@ final class ExpenseTravelListController: UIViewController {
 
     typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
     typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
-    typealias CellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, TravelInfoViewModel>
+    typealias CellRegistration = UICollectionView.CellRegistration<ExpenseTravelListCell, TravelInfoViewModel>
     
     // MARK: - Properties
     
@@ -92,28 +92,8 @@ final class ExpenseTravelListController: UIViewController {
     
     private func configureCollectionViewDataSource() {
         let travelCell =  CellRegistration { cell, indexPath, identifier in
-            var content = cell.defaultContentConfiguration()
-            content.image = UIImage(systemName: "airplane.departure")
-            content.imageProperties.tintColor = .primaryOrange
-            content.attributedText = NSAttributedString(
-                string: identifier.title,
-                attributes: [
-                    .font: UIFont.systemFont(ofSize: 18),
-                    .foregroundColor: UIColor.black!
-                ]
-            )
-            content.secondaryAttributedText = NSAttributedString(
-                string: Date.convertTravelString(
-                    start: identifier.startDate,
-                    end: identifier.endDate
-                ),
-                attributes: [
-                    .font: UIFont.systemFont(ofSize: 12),
-                    .foregroundColor: UIColor.grey4!
-                        
-                ]
-            )
-            cell.contentConfiguration = content
+            
+            cell.configureContent(with: identifier)
             
             // TODO: - 페이지 네이션 기준도 상수로 만들어서 사용하면 좋겠다.
             // pagination

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -90,19 +90,6 @@ final class ExpenseTravelListController: UIViewController {
         }
     }
     
-    // MARK: - Navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        let destinationViewController = segue.destination
-        
-        switch destinationViewController {
-        case let viewController as ExpenseListViewController:
-            print("ExpenseListViewcontroller로 이동합니다.")
-            viewController.travelID = selectedID
-        default:
-            print("잘못된 접근입니다.")
-        }
-    }
-    
     // MARK: - Collection View
     
     private func createCollectionViewListLayout() -> UICollectionViewCompositionalLayout {
@@ -148,8 +135,10 @@ extension ExpenseTravelListController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let viewModel = viewModel else { return }
         
+        let expenseListViewController = ExpenseListViewController()
         selectedID = viewModel.travelInfos[indexPath.row].uuid
-        navigationController?.pushViewController(ExpenseListViewController(), animated: true)
+        expenseListViewController.travelID = selectedID
+        navigationController?.pushViewController(expenseListViewController, animated: true)
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -98,7 +98,7 @@ final class ExpenseTravelListController: UIViewController {
             content.attributedText = NSAttributedString(
                 string: identifier.title,
                 attributes: [
-                    .font: UIFont.boldSystemFont(ofSize: 20),
+                    .font: UIFont.systemFont(ofSize: 18),
                     .foregroundColor: UIColor.black!
                 ]
             )
@@ -108,7 +108,7 @@ final class ExpenseTravelListController: UIViewController {
                     end: identifier.endDate
                 ),
                 attributes: [
-                    .font: UIFont.systemFont(ofSize: 14),
+                    .font: UIFont.systemFont(ofSize: 12),
                     .foregroundColor: UIColor.grey4!
                         
                 ]

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -11,9 +11,9 @@ import SnapKit
 
 final class ExpenseTravelListController: UIViewController {
 
-    typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
-    typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
-    typealias CellRegistration = UICollectionView.CellRegistration<ExpenseTravelListCell, TravelInfoViewModel>
+    private typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
+    private typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
+    private typealias CellRegistration = UICollectionView.CellRegistration<ExpenseTravelListCell, TravelInfoViewModel>
     
     // MARK: - Properties
     
@@ -26,7 +26,7 @@ final class ExpenseTravelListController: UIViewController {
     }()
     
     lazy var collectionView: UICollectionView = {
-        let layout = collectionViewListLayout()
+        let layout = createCollectionViewListLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
         collectionView.layer.cornerRadius = 12
@@ -34,11 +34,11 @@ final class ExpenseTravelListController: UIViewController {
         return collectionView
     }()
     
-    var travelDataSource: DataSource?
+    private var travelDataSource: DataSource?
     
     var selectedID: UUID?
     
-    var viewModel: ExpenseTravelViewModelProtocol? = ExpenseTravelViewModel()
+    private var viewModel: ExpenseTravelViewModelProtocol? = ExpenseTravelViewModel()
     
     // MARK: - Life Cycle
     
@@ -105,7 +105,7 @@ final class ExpenseTravelListController: UIViewController {
     
     // MARK: - Collection View
     
-    private func collectionViewListLayout() -> UICollectionViewCompositionalLayout {
+    private func createCollectionViewListLayout() -> UICollectionViewCompositionalLayout {
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
         listConfiguration.showsSeparators = false
         listConfiguration.backgroundColor = .white

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -29,7 +29,7 @@ final class ExpenseTravelListController: UIViewController {
         let layout = collectionViewListLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
-        collectionView.layer.cornerRadius = 7
+        collectionView.layer.cornerRadius = 12
         
         return collectionView
     }()
@@ -78,8 +78,15 @@ final class ExpenseTravelListController: UIViewController {
         }
         
         collectionView.snp.makeConstraints {
-            $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.verticalEdges.equalToSuperview().inset(0)
+//            $0.horizontalEdges.equalToSuperview().inset(16)
+//            $0.verticalEdges.equalToSuperview().inset(0)
+            
+            // TODO: - 위의 방법으로 constraint를 지정했더니 corenrradius가 적용되지 않습니다.
+            
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.equalTo(view.snp.leading).offset(16)
+            $0.trailing.equalTo(view.snp.trailing).offset(-16)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
@@ -26,6 +26,11 @@ final class TravelListCell: UICollectionViewListCell {
     /// - Parameter identifier: 여행 정보를 가지고 있는 `TravelInfoViewModel` 인스턴스
     func configure(with identifier: TravelInfoViewModel) {
         
+        contentConfiguration = createContentConfiguration(of: identifier)
+    }
+    
+    private func createContentConfiguration(of identifier: TravelInfoViewModel) -> UIListContentConfiguration {
+        
         var configuration = defaultContentConfiguration()
         configuration.image = UIImage(systemName: "airplane.departure")
         configuration.imageProperties.tintColor = .primaryOrange
@@ -46,7 +51,8 @@ final class TravelListCell: UICollectionViewListCell {
                 .foregroundColor: UIColor.grey4!
             ]
         )
-        contentConfiguration = configuration
+        
+        return configuration
     }
     
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
@@ -1,0 +1,12 @@
+//
+//  TravelListCell.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/17.
+//
+
+import UIKit
+
+final class TravelListCell: UICollectionViewListCell {
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
@@ -24,7 +24,7 @@ final class TravelListCell: UICollectionViewListCell {
     
     /// 셀의 기본적인 정보를 설정해주는 메서드
     /// - Parameter identifier: 여행 정보를 가지고 있는 `TravelInfoViewModel` 인스턴스
-    func configure(with identifier: TravelInfoViewModel) {
+    func configureContent(with identifier: TravelInfoViewModel) {
         
         contentConfiguration = createContentConfiguration(of: identifier)
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
@@ -9,4 +9,42 @@ import UIKit
 
 final class TravelListCell: UICollectionViewListCell {
     
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    /// 셀의 기본적인 정보를 설정해주는 메서드
+    /// - Parameter identifier: 여행 정보를 가지고 있는 `TravelInfoViewModel` 인스턴스
+    func configure(with identifier: TravelInfoViewModel) {
+        
+        var configuration = defaultContentConfiguration()
+        configuration.image = UIImage(systemName: "airplane.departure")
+        configuration.imageProperties.tintColor = .primaryOrange
+        configuration.attributedText = NSAttributedString(
+            string: identifier.title,
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 18),
+                .foregroundColor: UIColor.black!
+            ]
+        )
+        configuration.secondaryAttributedText = NSAttributedString(
+            string: Date.convertTravelString(
+                start: identifier.startDate,
+                end: identifier.endDate
+            ),
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 12),
+                .foregroundColor: UIColor.grey4!
+            ]
+        )
+        contentConfiguration = configuration
+    }
+    
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListCell.swift
@@ -20,6 +20,8 @@ final class TravelListCell: UICollectionViewListCell {
         super.init(coder: coder)
     }
     
+    // MARK: - Configuration
+    
     /// 셀의 기본적인 정보를 설정해주는 메서드
     /// - Parameter identifier: 여행 정보를 가지고 있는 `TravelInfoViewModel` 인스턴스
     func configure(with identifier: TravelInfoViewModel) {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -35,7 +35,7 @@ final class TravelListViewController: UIViewController {
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.backgroundColor = .white
-        collectionView.layer.cornerRadius = 7
+        collectionView.layer.cornerRadius = 12
         return collectionView
         
     }()

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -113,7 +113,7 @@ final class TravelListViewController: UIViewController {
     private func configureCollectionViewDataSource() {
         let travelCell = CellRegistration { cell, indexPath, identifier in
 
-            cell.configure(with: identifier)
+            cell.configureContent(with: identifier)
             
             if let viewModel = self.viewModel,
                indexPath.row == viewModel.travelInfos.count - 3 {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -15,7 +15,7 @@ final class TravelListViewController: UIViewController {
 
     private typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
     private typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
-    private typealias CellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, TravelInfoViewModel>
+    private typealias CellRegistration = UICollectionView.CellRegistration<TravelListCell, TravelInfoViewModel>
     
     // MARK: - Properties
     
@@ -112,29 +112,9 @@ final class TravelListViewController: UIViewController {
     
     private func configureCollectionViewDataSource() {
         let travelCell = CellRegistration { cell, indexPath, identifier in
-//            cell.configureLabel(with: identifier)
-            var content = cell.defaultContentConfiguration()
-            content.image = UIImage(systemName: "airplane.departure")
-            content.imageProperties.tintColor = .primaryOrange
-            content.attributedText = NSAttributedString(
-                string: identifier.title,
-                attributes: [
-                    .font: UIFont.systemFont(ofSize: 18),
-                    .foregroundColor: UIColor.black!
-                ]
-            )
-            content.secondaryAttributedText = NSAttributedString(
-                string: Date.convertTravelString(
-                    start: identifier.startDate,
-                    end: identifier.endDate
-                ),
-                attributes: [
-                    .font: UIFont.systemFont(ofSize: 12),
-                    .foregroundColor: UIColor.grey4!
-                ]
-            )
-            cell.contentConfiguration = content
-                        
+
+            cell.configure(with: identifier)
+            
             if let viewModel = self.viewModel,
                indexPath.row == viewModel.travelInfos.count - 3 {
                 DispatchQueue.main.async {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -125,7 +125,8 @@ final class TravelListViewController: UIViewController {
         }
         
         travelDataSource = DataSource(
-            collectionView: planCollectionView, cellProvider: { collectionView, indexPath, item in
+            collectionView: planCollectionView,
+            cellProvider: { collectionView, indexPath, item in
                 return collectionView.dequeueConfiguredReusableCell(
                     using: travelCell,
                     for: indexPath,

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -119,7 +119,7 @@ final class TravelListViewController: UIViewController {
             content.attributedText = NSAttributedString(
                 string: identifier.title,
                 attributes: [
-                    .font: UIFont.boldSystemFont(ofSize: 20),
+                    .font: UIFont.systemFont(ofSize: 18),
                     .foregroundColor: UIColor.black!
                 ]
             )
@@ -129,7 +129,7 @@ final class TravelListViewController: UIViewController {
                     end: identifier.endDate
                 ),
                 attributes: [
-                    .font: UIFont.systemFont(ofSize: 14),
+                    .font: UIFont.systemFont(ofSize: 12),
                     .foregroundColor: UIColor.grey4!
                 ]
             )

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
@@ -40,6 +40,7 @@ final class TravelListViewModel: TravelListViewModelProtocol {
     }
     
     func deleteTravel(with id: UUID) {
+        print(#function)
         let travels = PersistentManager.shared.fetch(request: Travel.fetchRequest())
         let deleteTravel = travels.filter { $0.id == id }
         

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
@@ -49,4 +49,8 @@ final class TravelListViewModel: TravelListViewModelProtocol {
             fetchTravelInfo()
         }
     }
+    
+    func reloadTravelInfo() {
+        
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
@@ -49,8 +49,5 @@ final class TravelListViewModel: TravelListViewModelProtocol {
             fetchTravelInfo()
         }
     }
-    
-    func reloadTravelInfo() {
-        
-    }
+
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- [x] 여행 목록 커스텀 셀 클래스를 생성하였습니다.
- [x] 여행 셀의 정보 설정을 커스텀 셀 메서드로 옮겼습니다.
- [x] 지출 여행목록 커스텀 셀 클래스를 생성하였습니다.
- [x] 지출 셀의 정보설정을 커스텀 셀 메서드로 옮겼습니다.
- [x] 지출 내역 뷰 컨트롤러를 생성하였습니다.
- [x] 지출 내역 컬렉션 뷰를 정의하였습니다.
- [x] 지출 여행목록 셀에 가격 레이블을 추가하였습니다.
- [x] 지출 내역의 글로벌헤더와 섹션 헤더를 등록하였습니다.

## 리뷰노트
> 고민, 과정, 궁금한점

다른과정은 그다지 어려움이 없었으나 헤더를 등록하는 부분에서 고민을 많이 했습니다.
저희 앱은 전반적으로 테이블 뷰와 같은 형식의 컬렉션뷰를 사용하고, 셀도 복잡한 형태가 아니라서 `UICollectionLayoutListConfiguration`을 사용해서 컬렉션 뷰의 레이아웃을 간단하게 작성할 수 있었습니다.
지출 내역과같은 경우에는 컬렉션 뷰의 전체에 적용되는 global header이고, 그외에 날짜도 표시하는 섹션헤더가 위치하기를 원했습니다.
layout의 configuration프로퍼티에 해당 헤더 정보들을 담아서 전달하면 된다는 것을 미리 알지 못해 기본적으로 제공하는 List형식의 Compositional Layout을 사용하지 않고, 기존에 직접 만드는 방식을 사용했었습니다. 
`UICollectionViewCompositionalLayout`이 configuration이라는 프로퍼티를 가지고 있고,
configuration은 `UICollectionViewCompositionalLayoutConfiguration` 타입입니다. 이 설정정보 안에 사용할 헤더들을 배열에담아서 등록해줄 수 있었습니다.

헤더의 경우에는 각각의 헤더를 구분해야했기 때문에 HeaderKind라는 열거형을 만들어 헤더가 어떤 헤더인지 구분할 수 있도록 하였습니다.
```swift
private func createLayoutConfiguration() ->  UICollectionViewCompositionalLayoutConfiguration {
    let globalHeaderSize = NSCollectionLayoutSize(
        widthDimension: .fractionalWidth(1.0),
        heightDimension: .absolute(100)
    )
    let sectionHeaderSize = NSCollectionLayoutSize(
        widthDimension: .fractionalWidth(1.0),
        heightDimension: .absolute(40)
    )
    
    let globalHeader = NSCollectionLayoutBoundarySupplementaryItem(
        layoutSize: globalHeaderSize,
        elementKind: HeaderKind.globalHeader,
        alignment: .top
    )
    globalHeader.pinToVisibleBounds = true
    
    let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
        layoutSize: sectionHeaderSize,
        elementKind: HeaderKind.sectionHeader,
        alignment: .top
    )
    
    let configuration = UICollectionViewCompositionalLayoutConfiguration()
    configuration.interSectionSpacing = 20
    configuration.boundarySupplementaryItems = [globalHeader, sectionHeader]
    
    return configuration
}
```

데이터가 없어서 아직 헤더 자체의 UI는 등록하지 않은 상태입니다. 추후 등록하겠습니다.

## 스크린샷
