### PR TITLE
[여행추가] 리팩토링 및 버그 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -30,7 +30,7 @@ final class TravelAddViewController: UIViewController {
     private lazy var travelTitleStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.spacing = 12
+        stackView.spacing = Metric.spacing
         
         return stackView
     }()
@@ -40,7 +40,7 @@ final class TravelAddViewController: UIViewController {
         stackView.axis = .vertical
         stackView.alignment = .fill
         stackView.distribution = .fill
-        stackView.spacing = 12
+        stackView.spacing = Metric.spacing
         
         return stackView
     }()
@@ -50,7 +50,6 @@ final class TravelAddViewController: UIViewController {
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fill
-        stackView.spacing = 0
         
         return stackView
     }()
@@ -67,8 +66,8 @@ final class TravelAddViewController: UIViewController {
     
     private lazy var travelTitleTextField: UITextField = {
         let textField = UITextField()
-        textField.placeholder = "여행 제목을 입력해주세요."
-        textField.layer.cornerRadius = 10
+        textField.placeholder = StringLiteral.travelTitlePlaceholder
+        textField.layer.cornerRadius = Metric.cornerRadius
         textField.backgroundColor = .grey1
         textField.textColor = .black
         textField.font = .systemFont(ofSize: 17, weight: .regular)
@@ -92,7 +91,7 @@ final class TravelAddViewController: UIViewController {
         let label = UILabel()
         label.textColor = .black
         label.clipsToBounds = true
-        label.layer.cornerRadius = 8
+        label.layer.cornerRadius = Metric.cornerRadius
         label.font = .systemFont(ofSize: 17, weight: .regular)
         label.backgroundColor = .grey1
         label.textAlignment = .center
@@ -104,7 +103,7 @@ final class TravelAddViewController: UIViewController {
         let label = UILabel()
         label.textColor = .black
         label.clipsToBounds = true
-        label.layer.cornerRadius = 8
+        label.layer.cornerRadius = Metric.cornerRadius
         label.font = .systemFont(ofSize: 17, weight: .regular)
         label.backgroundColor = .grey1
         label.textAlignment = .center
@@ -129,7 +128,7 @@ final class TravelAddViewController: UIViewController {
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .grey3
         button.isEnabled = false
-        button.layer.cornerRadius = 10
+        button.layer.cornerRadius = Metric.cornerRadius
         
         return button
     }()
@@ -342,5 +341,19 @@ extension TravelAddViewController: TravelAddViewDelegate {
     func isVaildView(isVaild: Bool) {
         addButton.isEnabled = isVaild
         addButton.backgroundColor = isVaild ? .primaryOrange : .grey3
+    }
+}
+
+// MARK: - Constants
+
+fileprivate extension TravelAddViewController {
+    
+    enum StringLiteral {
+        static let travelTitlePlaceholder = "여행 제목을 입력해주세요."
+    }
+    
+    enum Metric {
+        static let spacing: CGFloat = 12
+        static let cornerRadius: CGFloat = 10
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -190,26 +190,12 @@ final class TravelAddViewController: UIViewController {
     }
     
     private func configureSubviews() {
-        [scrollView].forEach {
-            view.addSubview($0)
-        }
+        view.addSubview(scrollView)
         scrollView.addSubview(contentView)
-        
-        [travelTitleStackView, travelDateStackView, addButton, customCalendar].forEach {
-            contentView.addSubview($0)
-        }
-        
-        [travelTitleLabel, travelTitleTextField].forEach {
-            travelTitleStackView.addArrangedSubview($0)
-        }
-        
-        [travelDateLabel, travelDateLabelStackView].forEach {
-            travelDateStackView.addArrangedSubview($0)
-        }
-        
-        [travelDateStartLabel, waveLabel, travelDateEndLabel].forEach {
-            travelDateLabelStackView.addArrangedSubview($0)
-        }
+        contentView.addSubviews(travelTitleStackView, travelDateStackView, addButton, customCalendar)
+        travelTitleStackView.addArrangedSubviews(travelTitleLabel, travelTitleTextField)
+        travelDateStackView.addArrangedSubviews(travelDateLabel, travelDateLabelStackView)
+        travelDateLabelStackView.addArrangedSubviews(travelDateStartLabel, waveLabel, travelDateEndLabel)
     }
     
     private func configureConstraint() {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -159,6 +159,7 @@ final class TravelAddViewController: UIViewController {
     // MARK: - Properties
     
     private let viewModel: TravelAddViewModel
+    private let dateFormatter: DateFormatter = Date.yearMonthDayDateFormatter
     
     // MARK: - Lifecycles
     
@@ -313,8 +314,6 @@ extension TravelAddViewController {
     }
     
     @objc func addButtonTouchUpInside() {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
         guard let name = travelTitleTextField.text,
               let startDateString = travelDateStartLabel.text,
               let startDate = dateFormatter.date(from: startDateString),

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -15,9 +15,9 @@ final class TravelAddViewController: UIViewController {
     
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-
         scrollView.backgroundColor = .white
         scrollView.showsVerticalScrollIndicator = false
+        
         return scrollView
     }()
     
@@ -29,47 +29,44 @@ final class TravelAddViewController: UIViewController {
     
     private lazy var travelTitleStackView: UIStackView = {
         let stackView = UIStackView()
-        
         stackView.axis = .vertical
-        stackView.alignment = .fill
-        stackView.distribution = .fill
         stackView.spacing = 12
+        
         return stackView
     }()
     
     private lazy var travelDateStackView: UIStackView = {
         let stackView = UIStackView()
-        
         stackView.axis = .vertical
         stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.spacing = 12
+        
         return stackView
     }()
     
     private lazy var travelDateLabelStackView: UIStackView = {
         let stackView = UIStackView()
-
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.spacing = 0
+        
         return stackView
     }()
     
     private lazy var travelTitleLabel: UILabel = {
         let label = UILabel()
-        
         label.text = "여행 제목"
         label.textColor = .black
         label.font = .systemFont(ofSize: 20, weight: .bold)
         label.textAlignment = .left
+        
         return label
     }()
     
     private lazy var travelTitleTextField: UITextField = {
         let textField = UITextField()
-        
         textField.placeholder = "여행 제목을 입력해주세요."
         textField.layer.cornerRadius = 10
         textField.backgroundColor = .grey1
@@ -77,62 +74,63 @@ final class TravelAddViewController: UIViewController {
         textField.font = .systemFont(ofSize: 17, weight: .regular)
         textField.addPadding(witdh: 8)
         textField.delegate = self
+        
         return textField
     }()
     
     private lazy var travelDateLabel: UILabel = {
         let label = UILabel()
-        
         label.text = "날짜"
         label.textColor = .black
         label.font = .systemFont(ofSize: 20, weight: .bold)
         label.textAlignment = .left
+        
         return label
     }()
     
     private lazy var travelDateStartLabel: UILabel = {
         let label = UILabel()
-        
         label.textColor = .black
         label.clipsToBounds = true
         label.layer.cornerRadius = 8
         label.font = .systemFont(ofSize: 17, weight: .regular)
         label.backgroundColor = .grey1
         label.textAlignment = .center
+        
         return label
     }()
     
     private lazy var travelDateEndLabel: UILabel = {
         let label = UILabel()
-        
         label.textColor = .black
         label.clipsToBounds = true
         label.layer.cornerRadius = 8
         label.font = .systemFont(ofSize: 17, weight: .regular)
         label.backgroundColor = .grey1
         label.textAlignment = .center
+        
         return label
     }()
     
     private lazy var waveLabel: UILabel = {
         let label = UILabel()
-
         label.text = "~"
         label.textColor = .black
         label.font = .systemFont(ofSize: 30, weight: .regular)
         label.backgroundColor = .white
         label.textAlignment = .center
+        
         return label
     }()
     
     private lazy var addButton: UIButton = {
         let button = UIButton()
-
         button.setTitle("여행 추가", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .grey3
         button.isEnabled = false
         button.layer.cornerRadius = 10
+        
         return button
     }()
     

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -167,6 +167,7 @@ final class TravelAddViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -143,12 +143,12 @@ final class TravelAddViewController: UIViewController {
         // 2개 날짜 선택시 라벨에 나타나도록
         customCalendar.completionHandler = { [weak self] dates in
             guard let self, dates.count > 1 else {
-                self?.viewModel.isVaildDate = false
+                self?.viewModel.isValidDate = false
                 return
             }
             self.travelDateStartLabel.text = dates[0]
             self.travelDateEndLabel.text = dates[1]
-            self.viewModel.isVaildDate = true
+            self.viewModel.isValidDate = true
         }
         return customCalendar
     }()
@@ -304,10 +304,10 @@ extension TravelAddViewController {
 extension TravelAddViewController {
     @objc func textFieldDidChange(_ sender: UITextField) {
         guard let text = sender.text, !text.isEmpty else {
-            viewModel.isVaildTextField = false
+            viewModel.isValidTextField = false
             return
         }
-        viewModel.isVaildTextField = true
+        viewModel.isValidTextField = true
     }
     
     @objc func addButtonTouchUpInside() {
@@ -338,7 +338,7 @@ extension TravelAddViewController: UITextFieldDelegate {
 // MARK: TravelAddViewDelegate
 
 extension TravelAddViewController: TravelAddViewDelegate {
-    func isVaildView(isVaild: Bool) {
+    func isValidView(isVaild: Bool) {
         addButton.isEnabled = isVaild
         addButton.backgroundColor = isVaild ? .primaryOrange : .grey3
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -142,13 +142,15 @@ final class TravelAddViewController: UIViewController {
         
         // 2개 날짜 선택시 라벨에 나타나도록
         customCalendar.completionHandler = { [weak self] dates in
-            guard let self, dates.count > 1 else {
-                self?.viewModel.isValidDate = false
-                return
+            self?.viewModel.travelDateTapped(dates: dates) { isSuccess in
+                if isSuccess {
+                    self?.travelDateStartLabel.text = dates[0]
+                    self?.travelDateEndLabel.text = dates[1]
+                } else {
+                    self?.presentErrorAlert(title: "날짜를 다시 입력해주세요")
+                }
+                
             }
-            self.travelDateStartLabel.text = dates[0]
-            self.travelDateEndLabel.text = dates[1]
-            self.viewModel.isValidDate = true
         }
         return customCalendar
     }()
@@ -303,11 +305,7 @@ extension TravelAddViewController {
 
 extension TravelAddViewController {
     @objc func textFieldDidChange(_ sender: UITextField) {
-        guard let text = sender.text, !text.isEmpty else {
-            viewModel.isValidTextField = false
-            return
-        }
-        viewModel.isValidTextField = true
+        viewModel.travelTitleDidChanged(title: sender.text)
     }
     
     @objc func addButtonTouchUpInside() {
@@ -338,9 +336,9 @@ extension TravelAddViewController: UITextFieldDelegate {
 // MARK: TravelAddViewDelegate
 
 extension TravelAddViewController: TravelAddViewDelegate {
-    func isValidView(isVaild: Bool) {
-        addButton.isEnabled = isVaild
-        addButton.backgroundColor = isVaild ? .primaryOrange : .grey3
+    func travelAddFormDidChange(isValid: Bool) {
+        addButton.isEnabled = isValid
+        addButton.backgroundColor = isValid ? .primaryOrange : .grey3
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
@@ -9,10 +9,17 @@ import Foundation
 
 protocol TravelAddViewProtocol: AnyObject {
     var delegate: TravelAddViewDelegate? { get set }
+    
     var isValidTextField: Bool { get set }
     var isValidDate: Bool { get set }
+    var isValidInput: Bool { get set }
+    
+    func travelTitleDidChanged(title: String?)
+    func travelDateTapped(dates: [String], completion: @escaping ((Bool) -> Void))
+    
+    func postTravel(travel: TravelDTO, completion: @escaping (() -> Void))
 }
 
 protocol TravelAddViewDelegate: AnyObject {
-    func isValidView(isVaild: Bool)
+    func travelAddFormDidChange(isValid: Bool)
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
@@ -9,10 +9,10 @@ import Foundation
 
 protocol TravelAddViewProtocol: AnyObject {
     var delegate: TravelAddViewDelegate? { get set }
-    var isVaildTextField: Bool { get set }
-    var isVaildDate: Bool { get set }
+    var isValidTextField: Bool { get set }
+    var isValidDate: Bool { get set }
 }
 
 protocol TravelAddViewDelegate: AnyObject {
-    func isVaildView(isVaild: Bool)
+    func isValidView(isVaild: Bool)
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
@@ -13,23 +13,23 @@ final class TravelAddViewModel: TravelAddViewProtocol {
     
     weak var delegate: TravelAddViewDelegate?
     
-    var isVaildTextField: Bool {
+    var isValidTextField: Bool {
         didSet {
-            delegate?.isVaildView(isVaild: isVaildTextField && isVaildDate)
+            delegate?.isValidView(isVaild: isValidTextField && isValidDate)
         }
     }
     
-    var isVaildDate: Bool {
+    var isValidDate: Bool {
         didSet {
-            delegate?.isVaildView(isVaild: isVaildTextField && isVaildDate)
+            delegate?.isValidView(isVaild: isValidTextField && isValidDate)
         }
     }
     
     // MARK: - Lifecycles
     
     init() {
-        isVaildTextField = false
-        isVaildDate = false
+        isValidTextField = false
+        isValidDate = false
     }
     
     // MARK: - CoreData Function

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
@@ -13,15 +13,11 @@ final class TravelAddViewModel: TravelAddViewProtocol {
     
     weak var delegate: TravelAddViewDelegate?
     
-    var isValidTextField: Bool {
+    var isValidTextField: Bool
+    var isValidDate: Bool
+    var isValidInput: Bool {
         didSet {
-            delegate?.isValidView(isVaild: isValidTextField && isValidDate)
-        }
-    }
-    
-    var isValidDate: Bool {
-        didSet {
-            delegate?.isValidView(isVaild: isValidTextField && isValidDate)
+            delegate?.travelAddFormDidChange(isValid: isValidInput)
         }
     }
     
@@ -30,6 +26,32 @@ final class TravelAddViewModel: TravelAddViewProtocol {
     init() {
         isValidTextField = false
         isValidDate = false
+        isValidInput = isValidTextField && isValidDate
+    }
+    
+    // MARK: - Functions
+    
+    func travelTitleDidChanged(title: String?) {
+        defer { isValidInput = isValidTextField && isValidDate }
+        guard let title, !title.isEmpty else {
+            isValidTextField = false
+            return
+        }
+        isValidTextField = true
+    }
+    
+    
+    func travelDateTapped(dates: [String], completion: @escaping ((Bool) -> Void)) {
+        defer {
+            isValidInput = isValidTextField && isValidDate
+            completion(isValidDate)
+        }
+        guard dates.count > 1 else {
+            isValidDate = false
+            return
+        }
+        isValidDate = true
+        
     }
     
     // MARK: - CoreData Function

--- a/Doesaegim/Doesaegim/Utility/Custom/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/CustomCalendar.swift
@@ -53,6 +53,7 @@ final class CustomCalendar: UICollectionView {
         configureSnapshot()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Doesaegim/Doesaegim/Utility/Custom/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/CustomCalendar.swift
@@ -32,7 +32,7 @@ final class CustomCalendar: UICollectionView {
     private var today = Date()
     private var calendar = Calendar.current
     private var dateComponents = DateComponents()
-    private var dateFormmater = DateFormatter()
+    private let dateFormmater = Date.yearMonthDateFormatter
     private let weeks: [String] = ["일", "월", "화", "수", "목", "금", "토"]
     private var days: [Item] = []
     private let touchOption: TouchOption
@@ -155,7 +155,6 @@ final class CustomCalendar: UICollectionView {
     private func configureCalendar() {
         dateComponents.year = calendar.component(.year, from: today)
         dateComponents.month = calendar.component(.month, from: today)
-        dateFormmater = Date.yearMonthDayDateFormatter
         setupCalendar()
         configureSnapshot()
     }

--- a/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
@@ -39,6 +39,13 @@ extension Date {
         return formatter
     }()
     
+    static let yearMonthDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월"
+        
+        return formatter
+    }()
+    
     /// 시작일 Date인스턴스와 종료일 Date 인스턴스를 받아 여행 목록시 부제목으로 사용되는 문자열을 반환한다.
     /// - Parameters:
     ///   - start: 시작일 `Date`인스턴스


### PR DESCRIPTION
## 변경사항
* 기존에 캘린더에서 헤더부분에 일 단위까지 나오는 부분을 수정했습니다.
* 여행추가가 되지 않는 오류를 해결했습니다.
* 기존에 여행추가시, 여행 제목과 날짜가 올바른지 판단을 뷰컨트롤러에서 했었는데 뷰모델의 역할로 변경해주었습니다.
* 오타를 수정하였습니다.
* @available(*, unavailable) 키워드를 사용하여 비가용성 정의하였습니다.

## 리뷰노트
한 줄 짜리 코드일 때, 함수안에 넣어서 선언하는게 더 좋을지 아니면 그냥 한 줄로 작성해야할지에 대한 고민이 생겼습니다..!
예를들어 네비게이션 타이틀을 변경하는 경우,  viewDidLoad에 `navigationItem.title = "여행 추가"` 한 줄로 작성을 하거나 아니면 `func configureNavigation()` 함수 안에 `navigationItem.title = "여행 추가"`를 작성해주고 viewDidload에 `configureNavigation()` 과 같이 작성하는 방식이 있을 것 같은데, 저는 한 줄로 작성할 수 있으면 한 줄로 작성을 하는 스타일인데, 팀원분들은 어떤 의견이신지 궁금합니다..!

## 스크린샷
|변경 전|변경 후|
|---|---|
|![IMG_0017](https://user-images.githubusercontent.com/77199797/202901299-a3be814e-d480-4438-921e-cf80d0a6006a.PNG)|![IMG_1536674ED6D9-1](https://user-images.githubusercontent.com/77199797/202901310-e05f4419-45db-4d95-9ba0-5a6983414cea.jpeg)|