### PR TITLE
[지출 목록] 지출목록 글로벌헤더와 섹션헤더의 분리

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
 		BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */; };
 		BB7D9A2A29261C0600BF2BD6 /* ExpenseListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */; };
+		BB9DB80E2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9DB80D2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift */; };
+		BB9DB8102928D09200102EC8 /* PersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9DB80F2928D09200102EC8 /* PersistentRepository.swift */; };
+		BB9DB8122928D0BA00102EC8 /* PersistentRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9DB8112928D0BA00102EC8 /* PersistentRepositoryProtocol.swift */; };
 		BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */; };
 		BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */; };
 		BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */; };
@@ -150,6 +153,9 @@
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
 		BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpensePlaceholdView.swift; sourceTree = "<group>"; };
 		BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListCell.swift; sourceTree = "<group>"; };
+		BB9DB80D2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewModelProtocol.swift; sourceTree = "<group>"; };
+		BB9DB80F2928D09200102EC8 /* PersistentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentRepository.swift; sourceTree = "<group>"; };
+		BB9DB8112928D0BA00102EC8 /* PersistentRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentRepositoryProtocol.swift; sourceTree = "<group>"; };
 		BBB31A362925F5E400C9E3A9 /* TravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A382925F77900C9E3A9 /* ExpenseTravelListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelListCell.swift; sourceTree = "<group>"; };
 		BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseListViewController.swift; sourceTree = "<group>"; };
@@ -320,6 +326,7 @@
 		A4CC04DA292351DC00BB678B /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				BB9DB8132928D0C300102EC8 /* PersistentStorage */,
 				A4CC04DB292351E700BB678B /* TravelScene */,
 			);
 			path = Repository;
@@ -454,9 +461,19 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		BB9DB8132928D0C300102EC8 /* PersistentStorage */ = {
+			isa = PBXGroup;
+			children = (
+				BB9DB8112928D0BA00102EC8 /* PersistentRepositoryProtocol.swift */,
+				BB9DB80F2928D09200102EC8 /* PersistentRepository.swift */,
+			);
+			path = PersistentStorage;
+			sourceTree = "<group>";
+		};
 		BBB31A3A2926003700C9E3A9 /* ExpenseList */ = {
 			isa = PBXGroup;
 			children = (
+				BB9DB80D2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift */,
 				BBB31A3C2926005F00C9E3A9 /* ViewModel */,
 				BBB31A3B2926005B00C9E3A9 /* View */,
 			);
@@ -850,6 +867,7 @@
 				B5C096B629235416007426B1 /* SearchingLocationViewController.swift in Sources */,
 				BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */,
 				BBE695D829228B560015FAD4 /* TravelListViewModel.swift in Sources */,
+				BB9DB80E2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift in Sources */,
 				B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */,
 				B5C096C429238091007426B1 /* SearchingLocationViewModel.swift in Sources */,
 				A4CC04A429221EEE00BB678B /* Plan+CoreDataClass.swift in Sources */,
@@ -866,6 +884,7 @@
 				A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */,
 				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
 				BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */,
+				BB9DB8122928D0BA00102EC8 /* PersistentRepositoryProtocol.swift in Sources */,
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
@@ -912,6 +931,7 @@
 				A4CC04C929227C7200BB678B /* PlanCollectionViewCell.swift in Sources */,
 				A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */,
 				A48E9946292512BC0029D57D /* CoreDataError.swift in Sources */,
+				BB9DB8102928D09200102EC8 /* PersistentRepository.swift in Sources */,
 				BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */,
 				BBD0D066291DED6A007D0D82 /* UIColor+.swift in Sources */,
 				BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
@@ -1,0 +1,8 @@
+//
+//  ExpenseListViewModelProtocol.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/19.
+//
+
+import Foundation

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
@@ -11,8 +11,11 @@ protocol ExpenseListViewModelProtocol: AnyObject {
     
     var delegate: ExpenseListViewModelDelegate? { get set }
     var expenseInfos: [ExpenseInfoViewModel] { get set }
+    var currentTravel: Travel? { get set }
     
-    func fetchExpenseData(with travelID: UUID)
+    func fetchCurrentTravel(with travelID: UUID?)
+    func fetchExpenseData()
+    func addExpenseData() // 추후 제거
     
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+
+protocol ExpenseListViewModelProtocol: AnyObject {
+    
+    var delegate: ExpenseListViewModelDelegate? { get set }
+    var expenseInfos: [ExpenseInfoViewModel] { get set }
+    
+    func fetchExpenseData(with travelID: UUID)
+    
+}
+
+protocol ExpenseListViewModelDelegate: AnyObject {
+    
+    /// 지출 항목에 변화가 생겼을 때 호출되는 delegate 함수입니다.
+    /// `expenseInfos` 데이터를 바탕으로 `UICollectionView`의 스냅샷을 반영하는데에 사용합니다.
+    func expenseListDidChanged()
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -52,8 +52,10 @@ final class ExpenseListCell: UICollectionViewListCell {
         }
     }
     
-    func configureContent() {
-        
+    func configureContent(with data: ExpenseInfoViewModel) {
+        var configuration = self.defaultContentConfiguration()
+        configuration.text = data.name
+        contentConfiguration = configuration
     }
     
 //    private func createContentConfiguration() -> UIContentConfiguration {

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -58,8 +58,6 @@ final class ExpenseListViewController: UIViewController {
 //        viewModel?.addExpenseData()
         viewModel?.fetchExpenseData()
         
-        print(viewModel?.expenseInfos)
-        
         // TODO: - 임시 데이터 추가코드 추후 삭제
         for _ in 0..<10 {
             
@@ -111,8 +109,11 @@ final class ExpenseListViewController: UIViewController {
     // MARK: - Collection View
     
     private func createCompositionalLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout {
-            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        let layout
+        = UICollectionViewCompositionalLayout { (
+            sectionIndex: Int,
+            layoutEnvironment: NSCollectionLayoutEnvironment
+        ) -> NSCollectionLayoutSection? in
             
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
@@ -160,7 +161,7 @@ final class ExpenseListViewController: UIViewController {
         return layout
     }
     
-    private func createLayoutConfiguration() ->  UICollectionViewCompositionalLayoutConfiguration {
+    private func createLayoutConfiguration() -> UICollectionViewCompositionalLayoutConfiguration {
         let globalHeaderSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(200)
@@ -180,7 +181,7 @@ final class ExpenseListViewController: UIViewController {
     }
     
     private func configureCollectionViewDataSource() {
-        let expenseCell = CellRegistration { cell, indexPath, identifier in
+        let expenseCell = CellRegistration { cell, _, identifier in
             cell.configureContent(with: identifier)
             // TODO: - 페이지네이션
         }
@@ -206,11 +207,11 @@ final class ExpenseListViewController: UIViewController {
         // TODO: - section Header 타이틀 바꾸기
         let sectionHeaderRegistration = SectionHeaderRegistration(
             elementKind: HeaderKind.sectionHeader
-        ) { supplementaryView, _, _ in
+        ) { _, _, _ in
         }
 
-        expenseDataSource?.supplementaryViewProvider = { [weak self] (collectionView, kind, indexPath) in
-            
+        // TODO: - 추후 self에 접근한다면 [weak self] 작성
+        expenseDataSource?.supplementaryViewProvider = { (collectionView, kind, indexPath) in
             
             if kind == HeaderKind.globalHeader {
                 let globalHeader = collectionView.dequeueConfiguredReusableSupplementary(

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -122,7 +122,7 @@ final class ExpenseListViewController: UIViewController {
             elementKind: HeaderKind.globalHeader,
             alignment: .top
         )
-        globalHeader.pinToVisibleBounds = true
+//        globalHeader.pinToVisibleBounds = true
         
 //        let sectionHeader = NSCollectionLayoutBoundarySupplementaryItem(
 //            layoutSize: sectionHeaderSize,

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -47,7 +47,11 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
         }
     }
     
-    func configureData(dateString: String) {
+    func configureData(date: Date) {
+        
+        let formatter = Date.yearMonthDayDateFormatter
+        let dateString = formatter.string(from: date)
+        
         dateLabel.text = dateString
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+final class ExpenseListViewModel {
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -7,6 +7,68 @@
 
 import Foundation
 
-final class ExpenseListViewModel {
+final class ExpenseListViewModel: ExpenseListViewModelProtocol {
     
+    // MARK: - Properties
+    
+    var delegate: ExpenseListViewModelDelegate?
+    var currentTravel: Travel?
+    var expenseInfos: [ExpenseInfoViewModel] {
+        didSet {
+            delegate?.expenseListDidChanged()
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    init() {
+        self.expenseInfos = []
+    }
+}
+
+extension ExpenseListViewModel {
+    
+    func fetchCurrentTravel(with travelID: UUID?) {
+        print(#function)
+        guard let id = travelID else { return }
+        
+        let travel = PersistentRepository.shared.fetchTravel(with: id)
+        if !travel.isEmpty {
+            currentTravel = travel.first!
+        }
+    }
+    
+    func fetchExpenseData() {
+//        print(#function)
+        guard let expenses = currentTravel?.expense?.allObjects as? [Expense] else { return }
+        var newExpenses: [ExpenseInfoViewModel] = []
+        for expense in expenses {
+            guard let viewModel = Expense.convertToViewModel(from: expense) else { continue }
+            newExpenses.append(viewModel)
+        }
+        expenseInfos.append(contentsOf: newExpenses)
+    }
+    
+    // 임시로 작성한 메서드. 추후 삭제 더미 지출 데이터를 추가한다.
+    func addExpenseData() {
+//        print(#function)
+        guard let travel = currentTravel else { return }
+        for count in 1...10 {
+            let dto = ExpenseDTO(
+                name: "\(count)번째 지출",
+                category: "식비",
+                content: "식비입니다 콘텐츠 콘텐츠 콘텐츠",
+                cost: 10000,
+                currency: "KR",
+                date: Date()
+            )
+            do {
+                let expense = try Expense.addAndSave(with: dto)
+                travel.addToExpense(expense)
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -54,13 +54,15 @@ extension ExpenseListViewModel {
 //        print(#function)
         guard let travel = currentTravel else { return }
         for count in 1...10 {
+            let dateComponents = DateComponents(year: 2022, month: 12, day: 25, hour: 17)
+            let date = Calendar.current.date(from: dateComponents)!
             let dto = ExpenseDTO(
                 name: "\(count)번째 지출",
                 category: "식비",
                 content: "식비입니다 콘텐츠 콘텐츠 콘텐츠",
                 cost: 10000,
                 currency: "KR",
-                date: Date()
+                date: date
             )
             do {
                 let expense = try Expense.addAndSave(with: dto)

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListCell.swift
@@ -55,7 +55,8 @@ final class ExpenseTravelListCell: UICollectionViewListCell {
         contentConfiguration = createContentConfiguration(of: identifier)
     }
     
-    private func createContentConfiguration(of identifier: TravelInfoViewModel) -> UIListContentConfiguration {
+    private func createContentConfiguration(of identifier: TravelInfoViewModel)
+    -> UIListContentConfiguration {
         
         var configuration = defaultContentConfiguration()
         configuration.image = UIImage(systemName: "airplane.departure")

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelListController.swift
@@ -11,9 +11,12 @@ import SnapKit
 
 final class ExpenseTravelListController: UIViewController {
 
-    private typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
-    private typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
-    private typealias CellRegistration = UICollectionView.CellRegistration<ExpenseTravelListCell, TravelInfoViewModel>
+    private typealias DataSource
+        = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
+    private typealias SnapShot
+        = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
+    private typealias CellRegistration
+        = UICollectionView.CellRegistration<ExpenseTravelListCell, TravelInfoViewModel>
     
     // MARK: - Properties
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/ViewModel/ExpenseTravelViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/ViewModel/ExpenseTravelViewModel.swift
@@ -27,7 +27,11 @@ final class ExpenseTravelViewModel: ExpenseTravelViewModelProtocol {
     
     func fetchTravelInfo() {
         
-        let travels = PersistentManager.shared.fetch(request: Travel.fetchRequest(), offset: travelInfos.count, limit: 10)
+        let travels = PersistentManager.shared.fetch(
+            request: Travel.fetchRequest(),
+            offset: travelInfos.count,
+            limit: 10
+        )
         var newTravelInfos: [TravelInfoViewModel] = []
         
         // TODO: - Travel 익스텐션으로

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -13,9 +13,12 @@ import SnapKit
 
 final class TravelListViewController: UIViewController {
 
-    private typealias DataSource = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
-    private typealias SnapShot = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
-    private typealias CellRegistration = UICollectionView.CellRegistration<TravelListCell, TravelInfoViewModel>
+    private typealias DataSource
+    = UICollectionViewDiffableDataSource<String, TravelInfoViewModel>
+    private typealias SnapShot
+    = NSDiffableDataSourceSnapshot<String, TravelInfoViewModel>
+    private typealias CellRegistration
+    = UICollectionView.CellRegistration<TravelListCell, TravelInfoViewModel>
     
     // MARK: - Properties
     
@@ -59,13 +62,19 @@ final class TravelListViewController: UIViewController {
         configureCollectionViewDataSource()
         
         // TODO: - 임시 데이터 저장, 추후 삭제
-        do {
+//        do {
 //            for index in 1...100 {
-//                try Travel.addAndSave(with: TravelDTO(name: "\(index)번째 여행!", startDate: Date(), endDate: Date()))
+//                try Travel.addAndSave(
+//                    with: TravelDTO(
+//                        name: "\(index)번째 여행!",
+//                        startDate: Date(),
+//                        endDate: Date()
+//                    )
+//                )
 //            }
-        } catch {
-            print(error.localizedDescription)
-        }
+//        } catch {
+//            print(error.localizedDescription)
+//        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/ViewModel/TravelListViewModel.swift
@@ -25,7 +25,11 @@ final class TravelListViewModel: TravelListViewModelProtocol {
     
     func fetchTravelInfo() {
         
-        let travels = PersistentManager.shared.fetch(request: Travel.fetchRequest(), offset: travelInfos.count, limit: 10)
+        let travels = PersistentManager.shared.fetch(
+            request: Travel.fetchRequest(),
+            offset: travelInfos.count,
+            limit: 10
+        )
 //        let travels = PersistentManager.shared.fetch(request: Travel.fetchRequest())
         var newTravelInfos: [TravelInfoViewModel] = []
         

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreData
 
-final class PersistentRepository: PersistnetRepositoryProtocol {
+final class PersistentRepository: PersistentRepositoryProtocol {
     
     static let shared: PersistentRepository = PersistentRepository()
     private init() {  }

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
@@ -6,19 +6,40 @@
 //
 
 import Foundation
+import CoreData
 
 final class PersistentRepository: PersistnetRepositoryProtocol {
-    func fetch<T>(with: T) -> [T] where T : NSManagedObject {
-        <#code#>
+    
+    
+    
+    let manager = PersistentManager.shared
+    
+    func fetchTravel() -> [Travel] {
+        let request = Travel.fetchRequest()
+        return manager.fetch(request: request)
     }
     
-    func fetch<T>(with: T, offset: Int, limit: Int) -> [T] where T : NSManagedObject {
-        <#code#>
+    func fetchExpense() -> [Expense] {
+        let request = Expense.fetchRequest()
+        return manager.fetch(request: request)
     }
     
-    func delete<T>(with: T) where T : NSManagedObject {
-        <#code#>
+    func fetchTravel(offset: Int, limit: Int) -> [Travel] {
+        let request = Travel.fetchRequest()
+        request.fetchOffset = offset
+        request.fetchLimit = limit
+        return manager.fetch(request: request)
     }
     
+    func fetchExpense(offset: Int, limit: Int) -> [Expense] {
+        let request = Expense.fetchRequest()
+        request.fetchOffset = offset
+        request.fetchLimit = limit
+        return manager.fetch(request: request)
+    }
+    
+//    func delete(type: EntityType) {
+//        <#code#>
+//    }
     
 }

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
@@ -39,6 +39,12 @@ final class PersistentRepository: PersistnetRepositoryProtocol {
         return manager.fetch(request: request)
     }
     
+    func fetchTravel(with id: UUID) -> [Travel] {
+        let request = Travel.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id.uuidString)
+        return manager.fetch(request: request)
+    }
+    
 //    func delete(type: EntityType) {
 //        <#code#>
 //    }

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
@@ -1,0 +1,24 @@
+//
+//  PersistentRepository.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/19.
+//
+
+import Foundation
+
+final class PersistentRepository: PersistnetRepositoryProtocol {
+    func fetch<T>(with: T) -> [T] where T : NSManagedObject {
+        <#code#>
+    }
+    
+    func fetch<T>(with: T, offset: Int, limit: Int) -> [T] where T : NSManagedObject {
+        <#code#>
+    }
+    
+    func delete<T>(with: T) where T : NSManagedObject {
+        <#code#>
+    }
+    
+    
+}

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepository.swift
@@ -10,7 +10,8 @@ import CoreData
 
 final class PersistentRepository: PersistnetRepositoryProtocol {
     
-    
+    static let shared: PersistentRepository = PersistentRepository()
+    private init() {  }
     
     let manager = PersistentManager.shared
     

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
@@ -22,7 +22,7 @@ protocol PersistnetRepositoryProtocol {
     ///   - offset: 불로어기 시작할 엔티티의 레코드번호
     ///   - limit: 최대로 불러올 수 있는 갯수
     /// - Returns: `NSManagedObject`타입 배열
-    ///
+    
     func fetchTravel(offset: Int, limit: Int) -> [Travel]
     func fetchExpense(offset: Int, limit: Int) -> [Expense]
     

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
@@ -1,0 +1,32 @@
+//
+//  PersistentRepositoryProtocol.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/19.
+//
+
+import Foundation
+import CoreData
+
+protocol PersistnetRepositoryProtocol {
+    
+    /// `NSManagedObject`타입의 데이터를 영구저장소로부터 패치해온다. 내부에서 request를 생성하고 PersistentManager에 요청을 보낸다.
+    /// - Parameter with: 패치할 엔티티타입
+    /// - Returns: `NSManagedObject` 타입 배열
+    func fetch<T: NSManagedObject>(with: T) -> [T]
+    
+    /// `NSManagedObject`타입의 데이터를 영구저장소로부터 불로온다. `offset`번째 레코드부터
+    /// 최대 `limit`개의 데이터를 불러온다. 내부에서 request를 생성하고 PersistentManager에
+    /// 요청을 보낸다.
+    /// - Parameters:
+    ///   - with: 패치할 엔티티 타입
+    ///   - offset: 불로어기 시작할 엔티티의 레코드번호
+    ///   - limit: 최대로 불러올 수 있는 갯수
+    /// - Returns: `NSManagedObject`타입 배열
+    func fetch<T: NSManagedObject>(with: T, offset: Int, limit: Int) -> [T]
+    
+    // TODO: - 추후 Result타입 반환하도록 생각
+    /// NSManagedObject를 상속하는 T타입의 엔티티를 영구저장소로부터삭제한다.
+    /// - Parameter with: 삭제할 데이터
+    func delete<T: NSManagedObject>(with: T)
+}

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
@@ -26,8 +26,6 @@ protocol PersistnetRepositoryProtocol {
     func fetchTravel(offset: Int, limit: Int) -> [Travel]
     func fetchExpense(offset: Int, limit: Int) -> [Expense]
     
-    // TODO: - 추후 Result타입 반환하도록 생각
-//    /// NSManagedObject를 상속하는 T타입의 엔티티를 영구저장소로부터삭제한다.
-//    /// - Parameter with: 삭제할 데이터
-//    func delete(type: EntityType)
+    func fetchTravel(with id: UUID) -> [Travel]
+    
 }

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
@@ -10,23 +10,24 @@ import CoreData
 
 protocol PersistnetRepositoryProtocol {
     
-    /// `NSManagedObject`타입의 데이터를 영구저장소로부터 패치해온다. 내부에서 request를 생성하고 PersistentManager에 요청을 보낸다.
-    /// - Parameter with: 패치할 엔티티타입
-    /// - Returns: `NSManagedObject` 타입 배열
-    func fetch<T: NSManagedObject>(with: T) -> [T]
+    /// 엔티티를 영구저장소로부터 패치해온다. 내부에서 request를 생성하고 PersistentManager에 요청을 보낸다.
+
+    func fetchTravel() -> [Travel]
+    func fetchExpense() -> [Expense]
     
-    /// `NSManagedObject`타입의 데이터를 영구저장소로부터 불로온다. `offset`번째 레코드부터
+    /// `NSManagedObject`타입의 엔티티를 영구저장소로부터 불러온다. `offset`번째 레코드부터
     /// 최대 `limit`개의 데이터를 불러온다. 내부에서 request를 생성하고 PersistentManager에
     /// 요청을 보낸다.
     /// - Parameters:
-    ///   - with: 패치할 엔티티 타입
     ///   - offset: 불로어기 시작할 엔티티의 레코드번호
     ///   - limit: 최대로 불러올 수 있는 갯수
     /// - Returns: `NSManagedObject`타입 배열
-    func fetch<T: NSManagedObject>(with: T, offset: Int, limit: Int) -> [T]
+    ///
+    func fetchTravel(offset: Int, limit: Int) -> [Travel]
+    func fetchExpense(offset: Int, limit: Int) -> [Expense]
     
     // TODO: - 추후 Result타입 반환하도록 생각
-    /// NSManagedObject를 상속하는 T타입의 엔티티를 영구저장소로부터삭제한다.
-    /// - Parameter with: 삭제할 데이터
-    func delete<T: NSManagedObject>(with: T)
+//    /// NSManagedObject를 상속하는 T타입의 엔티티를 영구저장소로부터삭제한다.
+//    /// - Parameter with: 삭제할 데이터
+//    func delete(type: EntityType)
 }

--- a/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
+++ b/Doesaegim/Doesaegim/Repository/PersistentStorage/PersistentRepositoryProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreData
 
-protocol PersistnetRepositoryProtocol {
+protocol PersistentRepositoryProtocol {
     
     /// 엔티티를 영구저장소로부터 패치해온다. 내부에서 request를 생성하고 PersistentManager에 요청을 보낸다.
 

--- a/Doesaegim/Doesaegim/Services/PersistentManager.swift
+++ b/Doesaegim/Doesaegim/Services/PersistentManager.swift
@@ -8,13 +8,13 @@
 import CoreData
 
 final class PersistentManager {
-
+    
     // MARK: - Properties
-
+    
     static let shared: PersistentManager = PersistentManager()
-
+    
     var context: NSManagedObjectContext { persistentContainer.viewContext }
-
+    
     private lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "Doesaegim")
         _ = container.loadPersistentStores(completionHandler: { (storeDescription, error) in
@@ -26,24 +26,24 @@ final class PersistentManager {
         container.viewContext.automaticallyMergesChangesFromParent = true
         return container
     }()
-
-
+    
+    
     // MARK: - Init(s)
-
+    
     private init() { }
-
-
+    
+    
     // MARK: - Core Data Saving support
-
+    
     func saveContext() throws {
         if context.hasChanges {
             try context.save()
         }
     }
-
-
+    
+    
     // MARK: - Core Data Fetching support
-
+    
     /// 코어데이터를 불러오기 위한 syntactic sugar
     func fetch<T: NSManagedObject>(request: NSFetchRequest<T>) -> [T] {
         do {
@@ -72,10 +72,10 @@ final class PersistentManager {
             return []
         }
     }
-
+    
     // MARK: - Core Data Deleting support
     /// TODO: 개발 단계 편의를 위한 메서드로 추후 삭제
-
+    
     /// 엔티티 인스턴스 삭제
     func delete(_ object: NSManagedObject) {
         context.delete(object)
@@ -98,13 +98,5 @@ final class PersistentManager {
         }
         
     }
-
-}
-
-enum EntityType {
-    case travel
-    case plan
-    case expense
-    case diary
-    case location
+    
 }

--- a/Doesaegim/Doesaegim/Services/PersistentManager.swift
+++ b/Doesaegim/Doesaegim/Services/PersistentManager.swift
@@ -100,3 +100,11 @@ final class PersistentManager {
     }
 
 }
+
+enum EntityType {
+    case travel
+    case plan
+    case expense
+    case diary
+    case location
+}

--- a/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
@@ -30,4 +30,22 @@ public class Expense: NSManagedObject {
         
         return expense
     }
+    
+    static func convertToViewModel(from expense: Expense) -> ExpenseInfoViewModel? {
+        
+        guard let id = expense.id,
+              let name = expense.name,
+              let content = expense.content,
+              let date = expense.date else { return nil }
+        
+        let viewModel = ExpenseInfoViewModel(
+            uuid: id,
+            name: name,
+            content: content,
+            cost: Int(expense.cost),
+            date: date
+        )
+        
+        return viewModel
+    }
 }


### PR DESCRIPTION
## 변경사항
- [x] 뷰에 보여줄 지출 모델, `ExpenseListViewModel`을 정의하였습니다.
- [x] 영구저장소를 다루어서 제공해줄 `PersistentRepository`와 그에 따른 프로토콜을 정의하였습니다.
- [x] CoreDataModel인 `Expense`에 뷰모델인 `ExpenseListViewModel`을 생성하는 메서드를 작성하였습니다.
- [x] 글로벌 헤더와 섹션헤더를 분리하였습니다.

## 리뷰노트
### section과 layout
섹션에 대한 헤더와 전체 컬렉션 뷰의 글로벌한 헤더를 어떻게 따로 설정해야 하는지에 대한 정보가 없어서 많이 고민했습니다.
섹션인 `NSCollectionLayoutSection`과 레이아웃인 `UICollectionViewCompositionalLayout` 모두 `boundarySupplementaryItems`라는 헤더로 설정할 배열을 가지고 있어, 동일한 변수의 이름 때문에 혼선이 있었습니다.
섹션마다 사용할 헤더의 경우에는 `UICollectionViewCompositionalLayout`을 설정하면서 클로저로 `NSCollectionLayoutSection?` 타입을 반환해야하는데, 이때 반환되는 section의 `boundarySupplementaryItems`에 담아주어야하고,
<img width="810" alt="image" src="https://user-images.githubusercontent.com/76734067/202908105-46d9249f-435c-436e-b621-b8f3f7772a71.png">

글로벌하게 반영할 헤더의 경우에는 레이아웃의 설정인 `UICollectionViewCompositionalLatoutConfiguration`클래스에서 `boundarySupplementaryItems`로 넘겨주고, layout의 configuration을 반영해주어야합니다.
<img width="759" alt="image" src="https://user-images.githubusercontent.com/76734067/202908089-829e96cb-eb2e-496d-9647-3c281cbf9144.png">

두가지의 `boundarySupplementaryItems` 프로퍼티이름이 같아서 다르다는 알아차리지 못해 때문에 많이 헤맸습니다...
최대한 UICollectionLayoutListConfiguration을 사용하여 구현하려 했으나, 결국에는 직접 섹션의 헤더를 등록해주어야했기 때문에 사용하지 못했습니다.

### PersistentRepository
영구저장소에 접근할 때 `PersistentManager`에 뷰 모델들이 직접접근하지 않고, 레포지토리를 통해 접근하도록 하였습니다. 뷰모델에서 레포지토리의 메서드들을 호출하면 레포지토리에서 request를 생성하고 `PersistentManager`와 접근하여 결과를 `PersistentRepository`에 반환, `PersistentRepository`는 뷰모델에 반환해주는 구조입니다.

## 스크린샷

https://user-images.githubusercontent.com/76734067/202908041-1a2ce88b-04dc-4b1d-88f6-b1d1d65e0c1f.mp4

