### PR TITLE
[일정 추가] 일정 추가 기능 구현

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
@@ -362,9 +362,9 @@ extension PlanAddViewController {
         else {
             return
         }
-        let dto = PlanDTO(name: name, date: date, content: content, travel: travel)
-        viewModel.postPlan(plan: dto) {
-            print("저장 성공!")
+        let planDTO = PlanDTO(name: name, date: date, content: content, travel: travel)
+        viewModel.postPlan(plan: planDTO) { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
         }
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
@@ -171,11 +171,13 @@ final class PlanAddViewController: UIViewController {
     // MARK: - Properties
     
     private let viewModel: PlanAddViewModel
+    private let travel: Travel?
     
     // MARK: - Lifecycles
     
-    init() {
+    init(travel: Travel?) {
         viewModel = PlanAddViewModel()
+        self.travel = travel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -201,6 +203,10 @@ final class PlanAddViewController: UIViewController {
             action: #selector(placeButtonTouchUpInside),
             for: .touchUpInside
         )
+        addButton.addTarget(
+            self,
+            action: #selector(addButtonTouchUpInside),
+            for: .touchUpInside)
         viewModel.delegate = self
     }
     
@@ -343,6 +349,24 @@ extension PlanAddViewController {
         searchingLocationViewController.delegate = self
         navigationController?.pushViewController(searchingLocationViewController, animated: true)
     }
+    
+    @objc func addButtonTouchUpInside() {
+        guard let name = planTitleTextField.text,
+              let dateString = dateInputButton.titleLabel?.text,
+              let date = Date.convertDateStringToDate(
+                dateString: dateString,
+                formatter: Date.yearMonthDayTimeDateFormatter
+              ),
+              let content = descriptionTextView.text,
+              let travel = travel
+        else {
+            return
+        }
+        let dto = PlanDTO(name: name, date: date, content: content, travel: travel)
+        viewModel.postPlan(plan: dto) {
+            print("저장 성공!")
+        }
+    }
 }
 
 // MARK: - TextField Delegate
@@ -398,9 +422,7 @@ extension PlanAddViewController: SearchingLocationViewControllerDelegate {
 extension PlanAddViewController: CalendarViewDelegate {
     func fetchDate(dateString: String) {
         dateInputButton.setTitle(dateString, for: .normal)
-        let dateFormatter = Date.yearMonthDayTimeDateFormatter
-        let date = dateFormatter.date(from: dateString)
-        viewModel.isValidDate(date: date)
+        viewModel.isValidDate(dateString: dateString)
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewModel.swift
@@ -65,15 +65,28 @@ final class PlanAddViewModel: PlanAddViewProtocol {
         isValidPlace = true
     }
     
-    func isValidDate(date: Date?) {
+    func isValidDate(dateString: String) {
         defer {
             isValidInput = isValidName && isValidPlace && isValidDate
         }
-        guard let date else {
+        guard let date = Date.convertDateStringToDate(
+            dateString: dateString,
+            formatter: Date.yearMonthDayTimeDateFormatter
+        ) else {
             isValidDate = false
             return
         }
         isValidDate = true
     }
     
+    func postPlan(plan: PlanDTO, completion: @escaping () -> Void) {
+        let result = Plan.addAndSave(with: plan)
+        switch result {
+        case .success:
+            completion()
+        case .failure(let error):
+            print(error.localizedDescription)
+            
+        }
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewModel.swift
@@ -35,15 +35,14 @@ final class PlanAddViewModel: PlanAddViewProtocol {
         isValidName = false
         isValidPlace = false
         isValidDate = false
-//        isValidInput = isValidName && isValidPlace && isValidDate
-        isValidInput = isValidName && isValidDate
+        isValidInput = isValidName && isValidPlace && isValidDate
     }
     
     // MARK: - Helpers
     
     func isValidPlanName(name: String?) {
         defer {
-            isValidInput = isValidName && isValidDate
+            isValidInput = isValidName && isValidPlace && isValidDate
         }
         guard let name,
               !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -54,18 +53,21 @@ final class PlanAddViewModel: PlanAddViewProtocol {
     }
     
     func isValidPlace(place: LocationDTO?) {
+        defer {
+            isValidInput = isValidName && isValidPlace && isValidDate
+        }
+        
         guard let place = place else {
             isValidPlace = false
             return
         }
-        
         selectedLocation = place
         isValidPlace = true
     }
     
     func isValidDate(date: Date?) {
         defer {
-            isValidInput = isValidName && isValidDate
+            isValidInput = isValidName && isValidPlace && isValidDate
         }
         guard let date else {
             isValidDate = false

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/ViewModel/PlanAddViewProtocol.swift
@@ -16,7 +16,9 @@ protocol PlanAddViewProtocol: AnyObject {
     
     func isValidPlanName(name: String?)
     func isValidPlace(place: LocationDTO?)
-    func isValidDate(date: Date?)
+    func isValidDate(dateString: String)
+    
+    func postPlan(plan: PlanDTO, completion: @escaping () -> Void)
 }
 
 protocol PlanAddViewDelegate: AnyObject {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -61,12 +61,11 @@ final class PlanListViewController: UIViewController {
         viewModel.fetchPlans()
     }
 
-
     // MARK: - NavigationBar Configuration Functions
 
     private func configureNavigationBar() {
         navigationItem.title = viewModel.navigationTitle
-        setRightBarAddButton(showing: PlanAddViewController())
+        setRightBarAddButton(showing: PlanAddViewController(travel: viewModel.travel))
     }
 
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanListViewModel.swift
@@ -11,6 +11,8 @@ final class PlanListViewModel {
     typealias SectionAndPlanID = (section: String, planID: UUID)
 
     // MARK: - Properties
+    
+    let travel: Travel
 
     let navigationTitle: String?
 
@@ -28,8 +30,6 @@ final class PlanListViewModel {
     
     private let repository: PlanRepository
     
-    private let travelID: UUID
-
     private var plans = [Plan]()
 
     /// 아직 뷰모델로 변환되지 않은 Plan의 시작 인덱스
@@ -45,10 +45,10 @@ final class PlanListViewModel {
     
     // MARK: - Init(s)
 
-    init(travelID: UUID, navgiationTitle: String, repository: PlanRepository) {
+    init(travel: Travel, repository: PlanRepository) {
         self.repository = repository
-        self.travelID = travelID
-        self.navigationTitle = navgiationTitle
+        self.travel = travel
+        self.navigationTitle = travel.name
     }
 
 
@@ -63,6 +63,10 @@ final class PlanListViewModel {
 
     func fetchPlans() {
         // TODO: 디바이스 별로 batchSize 계산하면 더 좋을듯?
+        guard let travelID = travel.id else {
+            planFetchHandler?(.failure(CoreDataError.fetchFailure(.travel)))
+            return
+        }
         let result = repository.fetchPlans(ofTravelID: travelID, batchSize: Metric.batchSize)
         switch result {
         case .success(let plans):

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
@@ -57,11 +57,13 @@ final class TravelAddViewModel: TravelAddViewProtocol {
     // MARK: - CoreData Function
     
     func postTravel(travel: TravelDTO, completion: @escaping (() -> Void)) {
-        do {
-            try Travel.addAndSave(with: travel)
+        let result = Travel.addAndSave(with: travel)
+        switch result {
+        case .success:
             completion()
-        } catch {
+        case .failure(let error):
             print(error.localizedDescription)
+            
         }
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -193,14 +193,21 @@ extension TravelListViewController: UICollectionViewDelegate {
         else {
             return
         }
+        let result = PersistentManager.shared.fetch(request: Travel.fetchRequest())
+        switch result {
+        case .success(let response):
+            guard let travel = response.first(where: { $0.id == travelViewModel.uuid }) else {
+                return
+            }
+            let planListViewModel = PlanListViewModel(
+                travel: travel,
+                repository: PlanLocalRepository()
+            )
+            show(PlanListViewController(viewModel: planListViewModel), sender: nil)
+        case .failure(let error):
+            print(error.localizedDescription)
+        }
 
-        let planListViewModel = PlanListViewModel(
-            travelID: travelViewModel.uuid,
-            navgiationTitle: travelViewModel.title,
-            repository: PlanLocalRepository()
-        )
-
-        show(PlanListViewController(viewModel: planListViewModel), sender: self)
     }
 }
 

--- a/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
@@ -61,4 +61,8 @@ extension Date {
 
         return periodString
     }
+    
+    static func convertDateStringToDate(dateString: String, formatter: DateFormatter) -> Date? {
+        return formatter.date(from: dateString)
+    }
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
* 기존에 일정 추가 화면에서, 장소를 입력하지 않아도 버튼이 활성화 되었는데, 장소를 입력해야만 버튼이 활성화 되도록 수정하였습니다.
* CoreData에 일정을 추가하는 기능을 구현하였습니다.
## 리뷰노트
> 고민, 과정, 궁금한점
* 일정을 CoreData에 저장할 때, Travel 객체가 필요합니다.
* 여행목록 -> 일정목록 화면으로 이동할 때, Travel에 대한 id만 갖고 있기 때문에, 여행을 추가할 때, Travel fetch를 한 번 더 해서 id 값과 같은 id인 Travel 객체를 반환해오도록 구현을 해야 하나 라는 생각을 했습니다.
* 하지만 여행목록 -> 일정목록으로 이동할 때, id만 넘겨주는 것이 아니라 Travel을 넘겨주면 따로 fetch할 필요가 없을 것이라고 생각했습니다.
* 지금은 여행목록 화면에서 Travel 객체를 사용하는게 아닌 TravelInfoViewModel을 사용하고 있어서 여행목록 -> 일정목록 화면으로 이동할 때, Travel 객체를 넘겨주려면 어쩔 수 없이 Travel에 대해 fetch 후, id 값을 비교해서 Travel 객체를 찾아서 넘겨줘야 하는 상황인 것 같은데, TravelInfoViewModel을 꼭 사용해야하는 있을지 궁금합니다..!
* 일정을 추가하고 pop하게 되면 일정목록 화면이 업데이트 되지가 않네요..!
  * 목록부분을 제가 구현하지 않아서 잘은 모르지만 일정을 가져오는 메서드를 `viewWillAppear()` 에서 하면 될 줄알고 시도해봤는데, 안되더라구요..! 어디가 문제인지 한 번 알아봐야 할 것 같아요.
* 화면을 전환하게 되면 최초에만 `viewDidLoad()`가 실행되고 다시 `push`를 하면 `viewDidLoad`는 실행되지 않고 `viewWillAppear`만 실행됩니다. 제가 알기로는 pop 될 때, 올라왔던 화면이 메모리에서 해제되기 때문에 다시 push해도 `viewDidLoad`가 동작하는 것으로 알고있었는데.. 잘 이해가 가지 않네요. 
  * 그래서 화면을 pop했다 다시 돌아와도 일정추가에 작성중이던 내용이 남아있더라구요. 혹시 아시는바가 있을까요?? 영상으로 첨부합니다! 

## 스크린샷
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/77199797/203041675-7d9d82c0-aaa5-4565-9318-aeea654f9f48.gif)
