### PR TITLE
[지출 추가] 환율 조회 캐시 구현 및 지출 추가시 CoreData 저장 기능 구현

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -104,8 +104,8 @@
 		EE3E29BC2923C870007C7FC7 /* TravelAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E29BB2923C870007C7FC7 /* TravelAddViewController.swift */; };
 		EE85FBC3292BA9B600FF0C7C /* ExpenseAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE85FBC2292BA9B600FF0C7C /* ExpenseAddViewController.swift */; };
 		EE85FBC6292BAADC00FF0C7C /* ExpenseAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE85FBC5292BAADC00FF0C7C /* ExpenseAddView.swift */; };
-		EEB6C4F4292C8CC50060A459 /* PickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4F3292C8CC50060A459 /* PickerViewController.swift */; };
-		EEB6C4F6292CA3990060A459 /* PickerViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4F5292CA3990060A459 /* PickerViewProtocol.swift */; };
+		EEB6C4F4292C8CC50060A459 /* ExpenseAddPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4F3292C8CC50060A459 /* ExpenseAddPickerViewController.swift */; };
+		EEB6C4F6292CA3990060A459 /* ExpenseAddPickerViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4F5292CA3990060A459 /* ExpenseAddPickerViewProtocol.swift */; };
 		EEB6C4F8292CA8DB0060A459 /* ExpenseAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4F7292CA8DB0060A459 /* ExpenseAddViewModel.swift */; };
 		EEB6C4FB292CA9200060A459 /* ExpenseAddViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4FA292CA9200060A459 /* ExpenseAddViewProtocol.swift */; };
 		EEB6C4FD292CC29B0060A459 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB6C4FC292CC29B0060A459 /* NetworkManager.swift */; };
@@ -240,8 +240,8 @@
 		EE3E29BD2923C8A7007C7FC7 /* CustomCalendarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendarHeaderView.swift; sourceTree = "<group>"; };
 		EE85FBC2292BA9B600FF0C7C /* ExpenseAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddViewController.swift; sourceTree = "<group>"; };
 		EE85FBC5292BAADC00FF0C7C /* ExpenseAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddView.swift; sourceTree = "<group>"; };
-		EEB6C4F3292C8CC50060A459 /* PickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerViewController.swift; sourceTree = "<group>"; };
-		EEB6C4F5292CA3990060A459 /* PickerViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerViewProtocol.swift; sourceTree = "<group>"; };
+		EEB6C4F3292C8CC50060A459 /* ExpenseAddPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddPickerViewController.swift; sourceTree = "<group>"; };
+		EEB6C4F5292CA3990060A459 /* ExpenseAddPickerViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddPickerViewProtocol.swift; sourceTree = "<group>"; };
 		EEB6C4F7292CA8DB0060A459 /* ExpenseAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddViewModel.swift; sourceTree = "<group>"; };
 		EEB6C4FA292CA9200060A459 /* ExpenseAddViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseAddViewProtocol.swift; sourceTree = "<group>"; };
 		EEB6C4FC292CC29B0060A459 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -775,7 +775,6 @@
 		EE116C542924AA0D0017B519 /* Custom */ = {
 			isa = PBXGroup;
 			children = (
-				EEB6C4F2292C8CAC0060A459 /* PickerView */,
 				EEB6C4F1292C8CA30060A459 /* Calendar */,
 			);
 			path = Custom;
@@ -827,6 +826,7 @@
 		EE85FBC1292BA9A600FF0C7C /* ExpenseAdd */ = {
 			isa = PBXGroup;
 			children = (
+				EEB6C4F2292C8CAC0060A459 /* PickerView */,
 				EEB6C501292CC8730060A459 /* Model */,
 				EE85FBC4292BAA9F00FF0C7C /* View */,
 				EEB6C4F9292CA8DF0060A459 /* ViewModel */,
@@ -858,8 +858,8 @@
 		EEB6C4F2292C8CAC0060A459 /* PickerView */ = {
 			isa = PBXGroup;
 			children = (
-				EEB6C4F3292C8CC50060A459 /* PickerViewController.swift */,
-				EEB6C4F5292CA3990060A459 /* PickerViewProtocol.swift */,
+				EEB6C4F3292C8CC50060A459 /* ExpenseAddPickerViewController.swift */,
+				EEB6C4F5292CA3990060A459 /* ExpenseAddPickerViewProtocol.swift */,
 			);
 			path = PickerView;
 			sourceTree = "<group>";
@@ -1105,7 +1105,7 @@
 				A4CC04CB29227E5C00BB678B /* Constants.swift in Sources */,
 				A4CC04CD2922818900BB678B /* UIView+AddSubviews.swift in Sources */,
 				BBFAC091291CBDD700D7FD57 /* Doesaegim.xcdatamodeld in Sources */,
-				EEB6C4F6292CA3990060A459 /* PickerViewProtocol.swift in Sources */,
+				EEB6C4F6292CA3990060A459 /* ExpenseAddPickerViewProtocol.swift in Sources */,
 				A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */,
 				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
 				B5D64E61292DF06400E1CC81 /* PlaceSearchButton.swift in Sources */,
@@ -1174,7 +1174,7 @@
 				BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */,
 				A4CC04C429226FC100BB678B /* String+Placeholders.swift in Sources */,
 				EEDB752F2925E8DD0069A7F5 /* CalendarViewController.swift in Sources */,
-				EEB6C4F4292C8CC50060A459 /* PickerViewController.swift in Sources */,
+				EEB6C4F4292C8CC50060A459 /* ExpenseAddPickerViewController.swift in Sources */,
 				EEB6C4FD292CC29B0060A459 /* NetworkManager.swift in Sources */,
 				EE85FBC6292BAADC00FF0C7C /* ExpenseAddView.swift in Sources */,
 			);

--- a/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/ExpenseDTO.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/ExpenseDTO.swift
@@ -15,4 +15,5 @@ struct ExpenseDTO {
     let cost: Int64
     let currency: String
     let date: Date
+    let travel: Travel
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeResponse.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ExchangeResponse: Decodable {
+struct ExchangeResponse: Codable {
     let currencyCode: String     // 통화코드
     let tradingStandardRate: String  // 매매기준율
     let currencyName: String      // 국가, 통화명

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 import SnapKit
 
-final class PickerViewController: UIViewController, PickerViewProtocol {
+final class ExpenseAddPickerViewController: UIViewController, ExpenseAddPickerViewProtocol {
     
     // MARK: - UI properties
     
@@ -64,7 +64,7 @@ final class PickerViewController: UIViewController, PickerViewProtocol {
     
     private let type: PickerType
     private var selectedIndex: Int = 0
-    var delegate: PickerViewDelegate?
+    var delegate: ExpenseAddPickerViewDelegate?
     
     // MARK: - Lifecycles
     
@@ -176,7 +176,7 @@ final class PickerViewController: UIViewController, PickerViewProtocol {
     
 }
 
-extension PickerViewController: UIPickerViewDataSource {
+extension ExpenseAddPickerViewController: UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
@@ -186,7 +186,7 @@ extension PickerViewController: UIPickerViewDataSource {
     }
 }
 
-extension PickerViewController: UIPickerViewDelegate {
+extension ExpenseAddPickerViewController: UIPickerViewDelegate {
     func pickerView(
         _ pickerView: UIPickerView,
         titleForRow row: Int,
@@ -211,7 +211,7 @@ extension PickerViewController: UIPickerViewDelegate {
 
 // MARK: Enum
 
-extension PickerViewController {
+extension ExpenseAddPickerViewController {
     enum PickerType {
         case category
         case moneyUnit

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
@@ -60,7 +60,7 @@ final class ExpenseAddPickerViewController: UIViewController, ExpenseAddPickerVi
     
     // TODO: - category 항목이 정해지면 수정 Enum으로?
     
-    private var category: [String] = ["식비", "경비", "숙박", "교통비", "항공비", "쇼핑", "관광", "기타"]
+    private var category: [ExpenseType] = ExpenseType.allCases
     
     private let type: PickerType
     private var selectedIndex: Int = 0
@@ -279,7 +279,7 @@ extension ExpenseAddPickerViewController: UIPickerViewDelegate {
             }
             return value[row]
         } else {
-            return category[row]
+            return category[row].rawValue
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewProtocol.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-protocol PickerViewProtocol: AnyObject {
-    var delegate: PickerViewDelegate? { get set }
+protocol ExpenseAddPickerViewProtocol: AnyObject {
+    var delegate: ExpenseAddPickerViewDelegate? { get set }
 }
 
-protocol PickerViewDelegate: AnyObject {
+protocol ExpenseAddPickerViewDelegate: AnyObject {
     func selectedExchangeInfo(item: ExchangeResponse)
     func selectedCategory(item: String)
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewProtocol.swift
@@ -13,5 +13,5 @@ protocol ExpenseAddPickerViewProtocol: AnyObject {
 
 protocol ExpenseAddPickerViewDelegate: AnyObject {
     func selectedExchangeInfo(item: ExchangeResponse)
-    func selectedCategory(item: String)
+    func selectedCategory(item: ExpenseType)
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddView.swift
@@ -214,7 +214,7 @@ final class ExpenseAddView: UIView {
         return label
     }()
     
-    private lazy var descriptionTextView: UITextView = {
+    lazy var descriptionTextView: UITextView = {
         let textView = UITextView()
         
         textView.layer.cornerRadius = 10

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -83,9 +83,9 @@ final class ExpenseAddViewController: UIViewController {
 
 extension ExpenseAddViewController {
     @objc func pickerViewButtonTouchUpInside(_ sender: UIButton) {
-        let type: PickerViewController.PickerType =
+        let type: ExpenseAddPickerViewController.PickerType =
         sender == rootView.moneyUnitButton ? .moneyUnit : .category
-        let pickerViewController = PickerViewController(type: type)
+        let pickerViewController = ExpenseAddPickerViewController(type: type)
         pickerViewController.delegate = self
         present(pickerViewController, animated: true)
     }
@@ -123,7 +123,7 @@ extension ExpenseAddViewController: CalendarViewDelegate {
 
 // MARK: - PickerDelegate
 
-extension ExpenseAddViewController: PickerViewDelegate {
+extension ExpenseAddViewController: ExpenseAddPickerViewDelegate {
     func selectedExchangeInfo(item: ExchangeResponse) {
         guard let exchangeRateType = ExchangeRateType(currencyCode: item.currencyCode) else { return }
         exchangeInfo = item

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -19,11 +19,13 @@ final class ExpenseAddViewController: UIViewController {
     
     private let viewModel: ExpenseAddViewModel
     private var exchangeInfo: ExchangeResponse?
+    private let travel: Travel?
     
     // MARK: - Lifecycles
     
-    init() {
+    init(travel: Travel?) {
         viewModel = ExpenseAddViewModel()
+        self.travel = travel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -40,6 +42,7 @@ final class ExpenseAddViewController: UIViewController {
         setKeyboardNotification()
         setAddTarget()
         viewModel.delegate = self
+//        viewModel.fetchCurrentTravel(with: "travelID")
     }
     
     // MARK: - Configure Function
@@ -76,6 +79,11 @@ final class ExpenseAddViewController: UIViewController {
             action: #selector(textFieldDidChange),
             for: .editingChanged
         )
+        rootView.addButton.addTarget(
+            self,
+            action: #selector(addButtonTouchUpInside),
+            for: .touchUpInside
+        )
     }
 }
 
@@ -110,6 +118,35 @@ extension ExpenseAddViewController {
         }
     }
     
+    @objc func addButtonTouchUpInside() {
+        guard let name = rootView.titleTextField.text,
+              let category = rootView.categoryButton.titleLabel?.text,
+              let content = rootView.descriptionTextView.text,
+              let exchangeInfo,
+              let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
+              let amountText = rootView.amountTextField.text,
+              let amount = Int(amountText),
+              let dateString = rootView.dateButton.titleLabel?.text,
+              let date = Date.yearMonthDayDateFormatter.date(from: dateString),
+              let travel = travel else {
+            return
+        }
+            
+        let expenseDTO = ExpenseDTO(
+            name: name,
+            category: category,
+            content: content,
+            cost: Int64(tradingStandardRate * Double(amount)),
+            currency: exchangeInfo.currencyName,
+            date: date,
+            travel: travel)
+        
+        viewModel.postExpense(expense: expenseDTO) { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+            print("지출 저장 성공!")
+        }
+    }
+    
 }
 
 // MARK: - CalendarDelegate
@@ -133,8 +170,8 @@ extension ExpenseAddViewController: ExpenseAddPickerViewDelegate {
         viewModel.exchangeLabelShow(amount: rootView.amountTextField.text, unit: item.tradingStandardRate)
     }
     
-    func selectedCategory(item: String) {
-        rootView.categoryButton.setTitle(item, for: .normal)
+    func selectedCategory(item: ExpenseType) {
+        rootView.categoryButton.setTitle(item.rawValue, for: .normal)
         viewModel.isValidCategoryItem(item: item)
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
@@ -12,6 +12,7 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
     // MARK: - Properties
     
     weak var delegate: ExpenseAddViewDelegate?
+    var currentTravel: Travel?
     
     var isValidName: Bool
     var isValidAmount: Bool
@@ -80,14 +81,9 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
         isValidUnit = true
     }
     
-    func isValidCategoryItem(item: String?) {
+    func isValidCategoryItem(item: ExpenseType) {
         defer {
             isValidInput = isValidName && isValidAmount && isValidUnit && isValidCategory && isValidDate
-        }
-        guard let item,
-              !item.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            isValidCategory = false
-            return
         }
         isValidCategory = true
     }
@@ -117,9 +113,14 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
         exchangeCalculataion = Int(rationalAmount * rationalUnit)
     }
     
-    
     func postExpense(expense: ExpenseDTO, completion: @escaping () -> Void) {
-        // TODO: 지출 추가 메서드 작성
+        let result = Expense.addAndSave(with: expense)
+        switch result {
+        case .success(let expense):
+            completion()
+        case .failure(let error):
+            print(error.localizedDescription)
+        }
     }
     
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
@@ -10,6 +10,8 @@ import Foundation
 protocol ExpenseAddViewProtocol: AnyObject {
     var delegate: ExpenseAddViewDelegate? { get set }
     
+    var currentTravel: Travel? { get set }
+    
     var isValidName: Bool { get set }
     var isValidAmount: Bool { get set }
     var isValidUnit: Bool { get set }
@@ -20,11 +22,10 @@ protocol ExpenseAddViewProtocol: AnyObject {
     func isValidNameTextField(text: String?)
     func isValidAmountTextField(text: String?)
     func isValidUnitItem(item: String?)
-    func isValidCategoryItem(item: String?)
+    func isValidCategoryItem(item: ExpenseType)
     func isValidDate(dateString: String?)
     
     func exchangeLabelShow(amount: String?, unit: String)
-    
     func postExpense(expense: ExpenseDTO, completion: @escaping () -> Void)
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -147,6 +147,8 @@ final class ExpenseListCell: UICollectionViewListCell {
             categoryImageView.image = UIImage(systemName: "car")
         case ExpenseType.room.rawValue:
             categoryImageView.image = UIImage(systemName: "bed.double")
+        case ExpenseType.shopping.rawValue:
+            categoryImageView.image = UIImage(systemName: "cart")
         case ExpenseType.other.rawValue:
             categoryImageView.image = UIImage(systemName: "dollarsign.circle")
         default:

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -232,7 +232,10 @@ final class ExpenseListViewController: UIViewController {
     // MARK: - Action
     
     @objc func didAddExpenseButtonTap() {
-        navigationController?.pushViewController(ExpenseAddViewController(), animated: true)
+        navigationController?.pushViewController(
+            ExpenseAddViewController(travel: viewModel?.currentTravel),
+            animated: true
+        )
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -83,7 +83,8 @@ extension ExpenseListViewModel {
                 content: "식비입니다 콘텐츠 콘텐츠 콘텐츠",
                 cost: 10000,
                 currency: "KR",
-                date: date
+                date: date,
+                travel: travel
             )
             
             let result = Expense.addAndSave(with: dto)

--- a/Doesaegim/Doesaegim/Utility/Constants.swift
+++ b/Doesaegim/Doesaegim/Utility/Constants.swift
@@ -24,3 +24,10 @@ enum ExchangeAPI {
     static let authkey = "wHpfEyMGBchJW4ipjjz4hXYximQmP0KR"
     static let dataCode = "AP01"
 }
+
+enum Constants {
+    
+    // MARK: - UserDefault
+    
+    static let exchangeValue = "exchangeValue"
+}

--- a/Doesaegim/Doesaegim/Utility/ExpenseType.swift
+++ b/Doesaegim/Doesaegim/Utility/ExpenseType.swift
@@ -17,7 +17,7 @@ import UIKit
 
 // MARK: - ExpenseType: 지금은 문자열로 구분
 
-enum ExpenseType: String {
+enum ExpenseType: String, CaseIterable {
     case food = "식비"
     case transportation = "교통비"
     case room = "숙박비"

--- a/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
@@ -53,6 +53,13 @@ extension Date {
         return formatter
     }()
     
+    static let yearMonthDaySplitDashDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        
+        return formatter
+    }()
+    
     /// 시작일 Date인스턴스와 종료일 Date 인스턴스를 받아 여행 목록시 부제목으로 사용되는 문자열을 반환한다.
     /// - Parameters:
     ///   - start: 시작일 `Date`인스턴스

--- a/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
@@ -25,6 +25,7 @@ public class Expense: NSManagedObject {
         expense.category = object.category
         expense.currency = object.currency
         expense.cost = object.cost
+        object.travel.addToExpense(expense)
         
         let result = PersistentManager.shared.saveContext()
         


### PR DESCRIPTION
## 변경사항
* 환율 정보를 담고있는 딕셔너리를 선언했습니다.
* #54 
1. 최초에 UserDefault에 환율 정보가 있는지 확인합니다.
2. 환율 정보가 없다면 오늘 날짜를 기준으로 API 요청을 보내서 환율 정보를 받아옵니다. 
   1. 오늘 날짜의 환율 정보를 불러올 수 없다면 (오전 12 ~ 10시 사이) API 요청을 보내 어제 날짜의 환율 정보를 불러옵니다.
   2. 환율 정보를 불러왔다면 (어제 날짜 기준이든, 오늘 날짜 기준이든) 딕셔너리에 [날짜: 환율정보]의 값을 저장하고 이를 디코딩해서 UserDefault에 저장합니다.
3. 환율 정보가 있다면 UserDefault에서 불러온 데이터를 [날짜: 환율정보] 형식으로 인코딩합니다.
    1.  오늘 날짜를 key 값으로 가진 환율정보가 있다면 API 요청을 하지 않고, 불러옵니다.
    2. 오늘 날짜를 key 값으로 가진 정보가 없다면, 어제 날짜를 key 값으로 가진 환율 정보를 확인합니다.
    3. 있다면 API 요청을 하지 않고 불러옵니다.
    4. 오늘 날짜, 어제 날짜를 key 값으로 가진 환율 정보가 없다면 API 요청을 보내도록 돌아갑니다. (2번으로)
* 지출 추가 기능 구현
  * 지출 추가시에도 일정 추가와 같이 Travel 객체가 필요하기 때문에 지출 목록에서 받아오도록 구현하였습니다.

## 리뷰노트
* 환율 정보를 하루에 한 번은 갱신하는 캐시를 구현하려다 보니, UserDefault와 사전자료형으로 구현하였는데 더 좋은 방법이 있을까 궁금합니다.. 딕셔너리 대신 NSCache를 사용하는게 더 좋았을까요..?!
* 지출을 추가하고 뒤로 pop 하게 되면 지출 내역 화면이 업데이트를 해줘야하는데 delegate나 closure, notificationCenter 등을 사용해서 구현할 수 있을 것 같은데 어떤 방법이 좋을까요..? 저는 항상 NotificationCenter를 사용했었는데, 이벤트 흐름을 알기 어려울 것 같아서 다른 방식으로 시도해보려고 합니다..!

## 스크린샷
![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/77199797/203520224-29f265b0-9cde-4d92-95d4-38fe00f71235.gif)
