### PR TITLE
[다이어리 작성] 여행, 장소, 제목, 내용 입력

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -37,6 +37,12 @@
 		B53763D5292B61A40073BF46 /* CustomChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763D4292B61A40073BF46 /* CustomChartItem.swift */; };
 		B53763E3292B99B80073BF46 /* PieceShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */; };
 		B53763E8292BA0760073BF46 /* PieceTextLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E7292BA0760073BF46 /* PieceTextLayer.swift */; };
+		A4EB25BF292BB4F1002D129A /* DiaryAddRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25BE292BB4F1002D129A /* DiaryAddRepository.swift */; };
+		A4EB25C2292BB518002D129A /* DiaryAddLocalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25C1292BB518002D129A /* DiaryAddLocalRepository.swift */; };
+		A4EB25C4292BB828002D129A /* DiaryAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25C3292BB828002D129A /* DiaryAddViewModel.swift */; };
+		A4EB25C9292C92CC002D129A /* DiaryAddViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25C8292C92CC002D129A /* DiaryAddViewModelDelegate.swift */; };
+		A4EB25CB292C92F1002D129A /* PickerDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25CA292C92F1002D129A /* PickerDataSource.swift */; };
+		A4EB25CD292C9775002D129A /* TemporaryDiary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EB25CC292C9775002D129A /* TemporaryDiary.swift */; };
 		B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D96252922301E00B510B8 /* TravelDTO.swift */; };
 		B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D9627292230CA00B510B8 /* PlanDTO.swift */; };
 		B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962B2922315500B510B8 /* LocationDTO.swift */; };
@@ -167,6 +173,12 @@
 		B53763D4292B61A40073BF46 /* CustomChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChartItem.swift; sourceTree = "<group>"; };
 		B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceShapeLayer.swift; sourceTree = "<group>"; };
 		B53763E7292BA0760073BF46 /* PieceTextLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceTextLayer.swift; sourceTree = "<group>"; };
+		A4EB25BE292BB4F1002D129A /* DiaryAddRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryAddRepository.swift; sourceTree = "<group>"; };
+		A4EB25C1292BB518002D129A /* DiaryAddLocalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryAddLocalRepository.swift; sourceTree = "<group>"; };
+		A4EB25C3292BB828002D129A /* DiaryAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryAddViewModel.swift; sourceTree = "<group>"; };
+		A4EB25C8292C92CC002D129A /* DiaryAddViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryAddViewModelDelegate.swift; sourceTree = "<group>"; };
+		A4EB25CA292C92F1002D129A /* PickerDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerDataSource.swift; sourceTree = "<group>"; };
+		A4EB25CC292C9775002D129A /* TemporaryDiary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryDiary.swift; sourceTree = "<group>"; };
 		B57D96252922301E00B510B8 /* TravelDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDTO.swift; sourceTree = "<group>"; };
 		B57D9627292230CA00B510B8 /* PlanDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDTO.swift; sourceTree = "<group>"; };
 		B57D962B2922315500B510B8 /* LocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDTO.swift; sourceTree = "<group>"; };
@@ -387,6 +399,7 @@
 			children = (
 				BB9DB8132928D0C300102EC8 /* PersistentStorage */,
 				A4CC04DB292351E700BB678B /* TravelScene */,
+				A4EB25C0292BB4F7002D129A /* DiaryScene */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -427,6 +440,25 @@
 			path = PieChart;
 			sourceTree = "<group>";
 		};
+		A4EB25C0292BB4F7002D129A /* DiaryScene */ = {
+			isa = PBXGroup;
+			children = (
+				A4EB25BE292BB4F1002D129A /* DiaryAddRepository.swift */,
+				A4EB25C1292BB518002D129A /* DiaryAddLocalRepository.swift */,
+			);
+			path = DiaryScene;
+			sourceTree = "<group>";
+		};
+		A4EB25C5292BCD26002D129A /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				A4EB25C3292BB828002D129A /* DiaryAddViewModel.swift */,
+				A4EB25C8292C92CC002D129A /* DiaryAddViewModelDelegate.swift */,
+				A4EB25CA292C92F1002D129A /* PickerDataSource.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		B57D962229222FC500B510B8 /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -440,6 +472,7 @@
 			isa = PBXGroup;
 			children = (
 				B57D96242922300400B510B8 /* PersistentDTO */,
+				A4EB25CC292C9775002D129A /* TemporaryDiary.swift */,
 			);
 			path = DTO;
 			sourceTree = "<group>";
@@ -490,6 +523,7 @@
 			isa = PBXGroup;
 			children = (
 				B5D64E5D292DF06400E1CC81 /* View */,
+				A4EB25C5292BCD26002D129A /* ViewModel */,
 			);
 			path = DiaryAdd;
 			sourceTree = "<group>";
@@ -1099,6 +1133,7 @@
 				B5D64E62292DF06400E1CC81 /* DiaryAddViewController.swift in Sources */,
 				BBD0D063291DE991007D0D82 /* SettingViewController.swift in Sources */,
 				BB3DB919292C649600C70D62 /* UIView+Frame.swift in Sources */,
+				A4EB25CD292C9775002D129A /* TemporaryDiary.swift in Sources */,
 				EEDB75312925F56D0069A7F5 /* CalendarProtocol.swift in Sources */,
 				A4CC04D32923308600BB678B /* DateCollectionHeaderView.swift in Sources */,
 				A4CC04CF292281B400BB678B /* UIStackView+AddArrangedSubviews.swift in Sources */,
@@ -1110,6 +1145,7 @@
 				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
 				B5D64E61292DF06400E1CC81 /* PlaceSearchButton.swift in Sources */,
 				BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */,
+				A4EB25CB292C92F1002D129A /* PickerDataSource.swift in Sources */,
 				BB9DB8122928D0BA00102EC8 /* PersistentRepositoryProtocol.swift in Sources */,
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				BB3DB922292CA79500C70D62 /* DiaryMapInfoViewModel.swift in Sources */,
@@ -1117,6 +1153,7 @@
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
 				BB3DB928292D092000C70D62 /* TempDiaryViewController.swift in Sources */,
+				A4EB25C2292BB518002D129A /* DiaryAddLocalRepository.swift in Sources */,
 				B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */,
 				B53763D5292B61A40073BF46 /* CustomChartItem.swift in Sources */,
 				B5C096B829235428007426B1 /* SearchingLocationView.swift in Sources */,
@@ -1156,6 +1193,7 @@
 				BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */,
 				BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */,
 				EE85FBC3292BA9B600FF0C7C /* ExpenseAddViewController.swift in Sources */,
+				A4EB25C9292C92CC002D129A /* DiaryAddViewModelDelegate.swift in Sources */,
 				EE116C592924AA0D0017B519 /* CustomCalendarHeaderView.swift in Sources */,
 				A4CC04A229221EEE00BB678B /* Diary+CoreDataClass.swift in Sources */,
 				EE116C5A2924AA0D0017B519 /* CustomCalendar.swift in Sources */,
@@ -1173,6 +1211,8 @@
 				BBD0D066291DED6A007D0D82 /* UIColor+.swift in Sources */,
 				BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */,
 				A4CC04C429226FC100BB678B /* String+Placeholders.swift in Sources */,
+				A4EB25C4292BB828002D129A /* DiaryAddViewModel.swift in Sources */,
+				A4EB25BF292BB4F1002D129A /* DiaryAddRepository.swift in Sources */,
 				EEDB752F2925E8DD0069A7F5 /* CalendarViewController.swift in Sources */,
 				EEB6C4F4292C8CC50060A459 /* PickerViewController.swift in Sources */,
 				EEB6C4FD292CC29B0060A459 /* NetworkManager.swift in Sources */,

--- a/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
@@ -13,5 +13,6 @@ struct DiaryDTO {
     let date: Date
     let images: [String]
     let title: String
+    let location: LocationDTO
     let travel: Travel
 }

--- a/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
@@ -13,4 +13,5 @@ struct DiaryDTO {
     let date: Date
     let images: [String]
     let title: String
+    let travel: Travel
 }

--- a/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
@@ -1,0 +1,18 @@
+//
+//  TemporaryDiary.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/22.
+//
+
+import Foundation
+
+/// DiaryAddViewModel에서 임시로 값을 들고 있기 위한 구조체
+struct TemporaryDiary {
+    let id = UUID()
+    var content: String?
+    var date: Date?
+    var images: [String]?
+    var title: String?
+    var travel: Travel?
+}

--- a/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
@@ -14,5 +14,6 @@ struct TemporaryDiary {
     var date: Date?
     var images: [String]?
     var title: String?
+    var location: LocationDTO?
     var travel: Travel?
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
@@ -22,24 +22,15 @@ final class DiaryAddView: UIView {
         return scrollView
     }()
 
-    private let contentStack: UIStackView = {
-        let stack = UIStackView()
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.axis = .vertical
-        stack.spacing = Metric.spacing
-        stack.alignment = .center
+    let travelPicker = UIPickerView()
 
-        return stack
-    }()
-
-    private let travelTextField: UITextField = {
+    let travelTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = StringLiteral.travelTextFieldPlaceholder
+        textField.font = textField.font?.withSize(FontSize.title)
 
         return textField
     }()
-
-    private let travelPicker = UIPickerView()
 
     private let placeSearchButton = PlaceSearchButton()
 
@@ -109,7 +100,17 @@ final class DiaryAddView: UIView {
         return view
     }()
 
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = Metric.spacing
+        stack.alignment = .center
 
+        return stack
+    }()
+
+    
     // MARK: - Properties
 
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
@@ -34,6 +34,13 @@ final class DiaryAddView: UIView {
 
     let placeSearchButton = PlaceSearchButton()
 
+    let titleTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = StringLiteral.titleTextFieldPlaceholder
+
+        return textField
+    }()
+
     private let addPhotoButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -75,13 +82,6 @@ final class DiaryAddView: UIView {
         control.currentPageIndicatorTintColor = .primaryOrange
 
         return control
-    }()
-
-    private let nameTextField: UITextField = {
-        let textField = UITextField()
-        textField.placeholder = StringLiteral.nameTextFieldPlaceholder
-
-        return textField
     }()
 
     private let contentTextView: UITextView = {
@@ -143,7 +143,7 @@ final class DiaryAddView: UIView {
         let contentStackSubviews = [
             travelTextField, placeSearchButton,
             imageSlider, pageControl,
-            nameTextField, divider, contentTextView
+            titleTextField, divider, contentTextView
         ]
         contentStack.addArrangedSubviews(contentStackSubviews)
         travelTextField.inputView = travelPicker
@@ -161,7 +161,7 @@ final class DiaryAddView: UIView {
     private func configureConstraints() {
         scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
         contentStack.snp.makeConstraints { $0.edges.width.equalToSuperview() }
-        [travelTextField, placeSearchButton, divider, nameTextField, contentTextView].forEach { view in
+        [travelTextField, placeSearchButton, divider, titleTextField, contentTextView].forEach { view in
             view.snp.makeConstraints { $0.leading.trailing.equalToSuperview().inset(Metric.inset) }
         }
         placeSearchButton.snp.makeConstraints { $0.height.equalTo(Metric.placeSearchButtonHeight) }
@@ -197,6 +197,6 @@ fileprivate extension DiaryAddView {
 
         static let squaredPlus = "plus.app"
 
-        static let nameTextFieldPlaceholder = "제목"
+        static let titleTextFieldPlaceholder = "제목"
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
@@ -32,7 +32,7 @@ final class DiaryAddView: UIView {
         return textField
     }()
 
-    private let placeSearchButton = PlaceSearchButton()
+    let placeSearchButton = PlaceSearchButton()
 
     private let addPhotoButton: UIButton = {
         let button = UIButton()
@@ -164,6 +164,7 @@ final class DiaryAddView: UIView {
         [travelTextField, placeSearchButton, divider, nameTextField, contentTextView].forEach { view in
             view.snp.makeConstraints { $0.leading.trailing.equalToSuperview().inset(Metric.inset) }
         }
+        placeSearchButton.snp.makeConstraints { $0.height.equalTo(Metric.placeSearchButtonHeight) }
         imageSlider.snp.makeConstraints {
             $0.width.equalToSuperview()
             $0.height.equalTo(imageSlider.snp.width)
@@ -187,6 +188,8 @@ fileprivate extension DiaryAddView {
         static let inset: CGFloat = 16
 
         static let cornerRadius: CGFloat = 8
+
+        static let placeSearchButtonHeight: CGFloat = 37
     }
 
     enum StringLiteral {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
@@ -41,6 +41,15 @@ final class DiaryAddView: UIView {
         return textField
     }()
 
+    let contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.sizeToFit()
+        textView.isScrollEnabled = false
+        textView.layer.cornerRadius = 8
+        
+        return textView
+    }()
+
     private let addPhotoButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -82,15 +91,6 @@ final class DiaryAddView: UIView {
         control.currentPageIndicatorTintColor = .primaryOrange
 
         return control
-    }()
-
-    private let contentTextView: UITextView = {
-        let textView = UITextView()
-        textView.sizeToFit()
-        textView.isScrollEnabled = false
-        textView.layer.cornerRadius = 8
-
-        return textView
     }()
 
     private let divider: UIView = {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
@@ -35,6 +35,7 @@ final class DiaryAddViewController: UIViewController {
         configureTravelPicker()
         configurePlaceSearchButton()
         configureNameTextField()
+        configureContentTextView()
     }
 
 
@@ -68,6 +69,11 @@ final class DiaryAddViewController: UIViewController {
         let action = UIAction { _ in self.viewModel.titleDidChange(to: textField.text) }
         textField.addAction(action, for: .editingChanged)
     }
+
+    private func configureContentTextView() {
+        rootView.contentTextView.delegate = self
+    }
+
 
     // MARK: - Keyboard Appearance Observing Functions
 
@@ -135,7 +141,6 @@ extension DiaryAddViewController: UIPickerViewDelegate {
 
 // MARK: - DiaryAddViewModelDelegate
 extension DiaryAddViewController: DiaryAddViewModelDelegate {
-
     func diaryValuesDidChange(_ diary: TemporaryDiary) {
         rootView.travelTextField.text = diary.travel?.name
         rootView.placeSearchButton.setTitle(diary.location?.name, for: .normal)
@@ -147,6 +152,13 @@ extension DiaryAddViewController: DiaryAddViewModelDelegate {
 extension DiaryAddViewController: SearchingLocationViewControllerDelegate {
     func searchingLocationViewController(didSelect location: LocationDTO) {
         viewModel.locationDidSelect(location)
+    }
+}
+
+// MARK: - UITextViewDelegate
+extension DiaryAddViewController: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        viewModel.contentDidChange(to: textView.text)
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
@@ -34,6 +34,7 @@ final class DiaryAddViewController: UIViewController {
         observeKeyBoardAppearance()
         configureTravelPicker()
         configurePlaceSearchButton()
+        configureNameTextField()
     }
 
 
@@ -60,6 +61,12 @@ final class DiaryAddViewController: UIViewController {
             self.show(controller, sender: self)
         }
         rootView.placeSearchButton.addAction(action, for: .touchUpInside)
+    }
+
+    private func configureNameTextField() {
+        let textField = rootView.titleTextField
+        let action = UIAction { _ in self.viewModel.titleDidChange(to: textField.text) }
+        textField.addAction(action, for: .editingChanged)
     }
 
     // MARK: - Keyboard Appearance Observing Functions
@@ -143,8 +150,8 @@ extension DiaryAddViewController: SearchingLocationViewControllerDelegate {
     }
 }
 
-// MARK: - Constants
 
+// MARK: - Constants
 fileprivate extension DiaryAddViewController {
 
     enum Metric {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
@@ -16,6 +16,7 @@ final class DiaryAddViewController: UIViewController {
 
     // MARK: - Properties
 
+    private let viewModel = DiaryAddViewModel(repository: DiaryAddLocalRepository())
 
 
     // MARK: - Life Cycle
@@ -29,15 +30,25 @@ final class DiaryAddViewController: UIViewController {
         super.viewDidLoad()
 
         configureNavigationBar()
+        bindToViewModel()
         observeKeyBoardAppearance()
+        configureTravelPicker()
     }
-
 
 
     // MARK: - Configuration Functions
 
     private func configureNavigationBar() {
         navigationItem.title = StringLiteral.navigationTitle
+    }
+
+    private func bindToViewModel() {
+        viewModel.delegate = self
+    }
+
+    private func configureTravelPicker() {
+        rootView.travelPicker.delegate = self
+        rootView.travelPicker.dataSource = viewModel.travelPickerDataSource
     }
 
 
@@ -80,6 +91,36 @@ final class DiaryAddViewController: UIViewController {
     @objc private func keyboardWillHide(notification: NSNotification) {
         rootView.scrollView.contentInset = .zero
         rootView.scrollView.scrollIndicatorInsets = .zero
+    }
+}
+
+
+// MARK: - UIPickerViewDelegate
+extension DiaryAddViewController: UIPickerViewDelegate {
+    func pickerView(
+        _ pickerView: UIPickerView,
+        titleForRow row: Int,
+        forComponent component: Int
+    ) -> String? {
+        viewModel.travelPickerDataSource.itemForRow(row)?.name
+    }
+
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        guard let travel = viewModel.travelPickerDataSource.itemForRow(row)
+        else {
+            return
+        }
+
+        viewModel.travelDidSelect(travel)
+    }
+}
+
+
+// MARK: - ViewModelDelegate
+extension DiaryAddViewController: DiaryAddViewModelDelegate {
+
+    func diaryValuesDidChange(_ diary: TemporaryDiary) {
+        rootView.travelTextField.text = diary.travel?.name
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
@@ -33,6 +33,7 @@ final class DiaryAddViewController: UIViewController {
         bindToViewModel()
         observeKeyBoardAppearance()
         configureTravelPicker()
+        configurePlaceSearchButton()
     }
 
 
@@ -51,6 +52,15 @@ final class DiaryAddViewController: UIViewController {
         rootView.travelPicker.dataSource = viewModel.travelPickerDataSource
     }
 
+    private func configurePlaceSearchButton() {
+        let action = UIAction { _ in
+            self.rootView.endEditing(true)
+            let controller = SearchingLocationViewController()
+            controller.delegate = self
+            self.show(controller, sender: self)
+        }
+        rootView.placeSearchButton.addAction(action, for: .touchUpInside)
+    }
 
     // MARK: - Keyboard Appearance Observing Functions
 
@@ -116,14 +126,22 @@ extension DiaryAddViewController: UIPickerViewDelegate {
 }
 
 
-// MARK: - ViewModelDelegate
+// MARK: - DiaryAddViewModelDelegate
 extension DiaryAddViewController: DiaryAddViewModelDelegate {
 
     func diaryValuesDidChange(_ diary: TemporaryDiary) {
         rootView.travelTextField.text = diary.travel?.name
+        rootView.placeSearchButton.setTitle(diary.location?.name, for: .normal)
     }
 }
 
+
+// MARK: - SearchingLocationViewControllerDelegate
+extension DiaryAddViewController: SearchingLocationViewControllerDelegate {
+    func searchingLocationViewController(didSelect location: LocationDTO) {
+        viewModel.locationDidSelect(location)
+    }
+}
 
 // MARK: - Constants
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/PlaceSearchButton.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/PlaceSearchButton.swift
@@ -25,13 +25,22 @@ final class PlaceSearchButton: UIButton {
     }
 
 
+    // MARK: - Override Functions
+
+    /// title이 nil인 경우 항상 placeholder text를 나타내기 위해 오버라이드
+    override func setTitle(_ title: String?, for state: UIControl.State) {
+        let newTitle = title == nil ? StringLiteral.placeholderText : title
+        super.setTitle(newTitle, for: state)
+    }
+
+
     // MARK: - Configuration Functions
 
     private func configureViews() {
         layer.cornerRadius = Metric.cornerRadius
         backgroundColor = .grey1
         setTitleColor(.grey3, for: .normal)
-        setTitle(StringLiteral.title, for: .normal)
+        setTitle(StringLiteral.placeholderText, for: .normal)
         titleLabel?.changeFontSize(to: FontSize.body)
         setImage(.init(systemName: StringLiteral.imageName), for: .normal)
         titleEdgeInsets = Metric.titleEdgeInsets
@@ -49,13 +58,13 @@ fileprivate extension PlaceSearchButton {
     enum Metric {
         static let cornerRadius: CGFloat = 10
 
-        static let titleEdgeInsets = UIEdgeInsets(top: .zero, left: 15, bottom: .zero, right: -5)
+        static let titleEdgeInsets = UIEdgeInsets(top: .zero, left: 10, bottom: .zero, right: -5)
 
-        static let imageEdgeInsets = UIEdgeInsets(top: .zero, left: 10, bottom: .zero, right: 5)
+        static let imageEdgeInsets = UIEdgeInsets(top: .zero, left: 5, bottom: .zero, right: 5)
     }
 
     enum StringLiteral {
-        static let title = "장소를 검색해주세요"
+        static let placeholderText = "장소를 검색해주세요"
 
         static let imageName = "magnifyingglass"
     }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -48,4 +48,9 @@ final class DiaryAddViewModel {
         temporaryDiary.location = location
         delegate?.diaryValuesDidChange(temporaryDiary)
     }
+
+    func titleDidChange(to title: String?) {
+        temporaryDiary.title = title
+        delegate?.diaryValuesDidChange(temporaryDiary)
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  DiaryAddViewModel.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/21.
+//
+
+import Foundation
+
+final class DiaryAddViewModel {
+
+    // MARK: - Properties
+
+    weak var delegate: DiaryAddViewModelDelegate?
+
+    lazy var travelPickerDataSource: PickerDataSource<Travel> = {
+        let result = repository.fetchAllTravels()
+
+        switch result {
+        case .success(let travels):
+            return PickerDataSource(items: travels)
+        case .failure(let error):
+            return PickerDataSource(items: [])
+        }
+    }()
+
+    private let repository: DiaryAddRepository
+
+    /// 유저의 입력값을 관리하기 위한 객체
+    private var temporaryDiary = TemporaryDiary()
+
+
+    // MARK: - Init(s)
+
+    init(repository: DiaryAddRepository) {
+        self.repository = repository
+    }
+
+
+    // MARK: - Functions
+
+    func travelDidSelect(_ travel: Travel) {
+        temporaryDiary.travel = travel
+        delegate?.diaryValuesDidChange(temporaryDiary)
+    }
+}

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -53,4 +53,9 @@ final class DiaryAddViewModel {
         temporaryDiary.title = title
         delegate?.diaryValuesDidChange(temporaryDiary)
     }
+    
+    func contentDidChange(to content: String?) {
+        temporaryDiary.content = content
+        delegate?.diaryValuesDidChange(temporaryDiary)
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -37,10 +37,15 @@ final class DiaryAddViewModel {
     }
 
 
-    // MARK: - Functions
+    // MARK: - User Interaction Handling Functions
 
     func travelDidSelect(_ travel: Travel) {
         temporaryDiary.travel = travel
+        delegate?.diaryValuesDidChange(temporaryDiary)
+    }
+
+    func locationDidSelect(_ location: LocationDTO) {
+        temporaryDiary.location = location
         delegate?.diaryValuesDidChange(temporaryDiary)
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModelDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  DiaryAddViewModelDelegate.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/22.
+//
+
+import Foundation
+
+protocol DiaryAddViewModelDelegate: AnyObject {
+
+    func diaryValuesDidChange(_ diary: TemporaryDiary)
+}

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/PickerDataSource.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/PickerDataSource.swift
@@ -1,0 +1,49 @@
+//
+//  PickerDataSource.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/22.
+//
+
+import UIKit
+
+/// Picker가 나타낼 데이터  셋인 T의 배열을 갖고 있는 UIPickerViewDataSource
+final class PickerDataSource<T>: NSObject, UIPickerViewDataSource {
+
+    // MARK: - Enums
+
+    enum Section: CaseIterable {
+        case main
+    }
+
+
+    // MARK: - Properties
+
+    private let items: [T]
+
+
+    // MARK: - Init
+
+    init(items: [T]) {
+        self.items = items
+    }
+
+
+    // MARK: - DataSource Functions
+
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        Section.allCases.count
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        items.count
+    }
+
+
+    // MARK: - Syntatic sugar Functions
+
+    /// 해당 위치에 아이템이 있는 경우 아이템, 없으면 nil 리턴
+    func itemForRow(_ row: Int) -> T? {
+        items.indices ~= row ? items[row] : nil
+    }
+}

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
@@ -46,6 +46,7 @@ final class SearchingLocationView: UIView {
     // MARK: - Functions
     
     private func configureViews() {
+        backgroundColor = .white
         configureSubviews()
         configureConstraints()
     }

--- a/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAddLocalRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAddLocalRepository.swift
@@ -1,0 +1,39 @@
+//
+//  DiaryAddLocalRepository.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/21.
+//
+
+import Foundation
+
+struct DiaryAddLocalRepository: DiaryAddRepository {
+
+
+    // MARK: - Properties
+
+    private let persistentManager = PersistentManager.shared
+
+
+    // MARK: - Functions
+
+    func fetchAllTravels() -> Result<[Travel], Error> {
+        let request = Travel.fetchRequest()
+        request.fetchBatchSize = Metric.fetchBatchSize
+
+        return persistentManager.fetch(request: request)
+    }
+    
+    func addDiary(_ diaryDTO: DiaryDTO) -> Result<Diary, Error> {
+        Diary.addAndSave(with: diaryDTO)
+    }
+}
+
+
+// MARK: - Constants
+fileprivate extension DiaryAddLocalRepository {
+
+    enum Metric {
+        static let fetchBatchSize = 10
+    }
+}

--- a/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAddRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAddRepository.swift
@@ -1,0 +1,15 @@
+//
+//  DiaryAddRepository.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/11/21.
+//
+
+import Foundation
+
+protocol DiaryAddRepository {
+
+    func fetchAllTravels() -> Result<[Travel], Error>
+
+    func addDiary(_ diaryDTO: DiaryDTO) -> Result<Diary, Error> 
+}

--- a/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
@@ -23,6 +23,7 @@ public class Diary: NSManagedObject {
         diary.images = object.images
         diary.title = object.title
         diary.content = object.content
+        object.travel.addToDiary(diary)
         
         let result = PersistentManager.shared.saveContext()
         

--- a/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
@@ -23,6 +23,10 @@ public class Diary: NSManagedObject {
         diary.images = object.images
         diary.title = object.title
         diary.content = object.content
+
+        let location = Location.add(with: object.location)
+        diary.location = location
+        
         object.travel.addToDiary(diary)
         
         let result = PersistentManager.shared.saveContext()

--- a/Doesaegim/NSManagedObjectClass/Location+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Location+CoreDataClass.swift
@@ -13,14 +13,20 @@ import Foundation
 public class Location: NSManagedObject {
     
     // MARK: - Functions
-    
-    @discardableResult
-    static func addAndSave(with object: LocationDTO) -> Result<Location, Error> {
+
+    static func add(with object: LocationDTO) -> Location {
         let context = PersistentManager.shared.context
         let location = Location(context: context)
         location.name = object.name
         location.latitude = object.latitude
         location.longitude = object.longitude
+
+        return location
+    }
+    
+    @discardableResult
+    static func addAndSave(with object: LocationDTO) -> Result<Location, Error> {
+        let location = add(with: object)
         
         let result = PersistentManager.shared.saveContext()
         


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게
 
- #53 
- #59 
- #66 
- #67

- 여행 텍스트필드를 누르면 커스텀 피커가 뜨고 여행을 선택할 수 있도록 구현했습니다. 
- 장소 버튼을 누르면 보경님이 만들어주신 장소 선택 컨트롤러로 이동후 선택사항을 반영할 수 있도록 구현했습니다. 
- 제목, 내용을 입력할 수 있도록 구현했습니다. 
- 기존에 다이어리 생성 및 추가 시 장소가 누락되고 있어서 해당 부분을 수정했습니다. 

<br>

## 리뷰노트
> 고민, 과정, 궁금한점
- 코멘트로 달겠습니다!

## 스크린샷

![Simulator Screen Recording - iPhone 14 - 2022-11-22 at 15 08 55](https://user-images.githubusercontent.com/81314063/203564118-a30fb376-af6d-4191-b719-a69774f1b811.gif)

여행 선택 시 텍스트필드에 반영

![Simulator Screen Recording - iPhone 14 - 2022-11-23 at 22 49 33](https://user-images.githubusercontent.com/81314063/203563487-8851e87a-ab99-4956-9b67-d91f109f645c.gif)

장소 선택 시 버튼에 반영 

![Simulator Screen Recording - iPhone 14 - 2022-11-23 at 22 49 47](https://user-images.githubusercontent.com/81314063/203563446-6a4bf8c5-30aa-4142-9184-18e2d007932a.gif)

제목/내용 누르면 키보드에 가리지 않도록 위치 이동
