### PR TITLE
[환율 조회] 버그 해결 및 네트워크 통신 리팩토링

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/PickerView/ExpenseAddPickerViewController.swift
@@ -227,6 +227,9 @@ final class ExpenseAddPickerViewController: UIViewController, ExpenseAddPickerVi
                 
                 let cacheKey = NSString(string: fetchExchangeInfoDate)
                 exchangeMemoryCache.setObject(info as NSArray, forKey: cacheKey)
+            } else {
+                // 날짜가 다르면 오늘 날짜로 api 요청
+                fetchExchangeInfo(day: todayDateConvertToString())
             }
             
         } else {


### PR DESCRIPTION
## 변경사항
* 환율 조회 API 오류 수정
* 기존 네트워크 통신 성공 시, completion handler로 처리를 해줬는데, URLSession에 async/await API를 사용하여 리팩토링

## 리뷰노트
* 환율 조회 API가 작동이 안됐던 이유는, UserDefault에 환율 조회 API를 조회한 날짜를 담고 있는데, 그 날짜가 오늘 날짜와 다르면 API 요청을 보내야하는데 보내지 않았습니다..
* async/await을 처음 사용해봤는데, 코드가 깔끔해지고 알아보기 더 쉽다고 느꼈습니다. 또한 클로저로 넘겨주지 않아서 조회 성공시 처리해야할 부분에서 변수를 캡처하지 않는다는 장점도 있는 것 같아요.

## 스크린샷
* 기존과 동일하기 때문에 스크린샷은 패스하겠습니다!
