### PR TITLE
[커스텀 캘린더] 캘린더 기능 추가

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		EE116C5C2924C9390017B519 /* TravelAddViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116C5B2924C9390017B519 /* TravelAddViewModel.swift */; };
 		EE116C5E2924CB6B0017B519 /* TravelAddViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116C5D2924CB6B0017B519 /* TravelAddViewProtocol.swift */; };
 		EE116C632924EC860017B519 /* PlanAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE116C622924EC860017B519 /* PlanAddViewController.swift */; };
+		EE12EA112934AEFA00D41DFE /* CustomCalendarCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12EA102934AEFA00D41DFE /* CustomCalendarCellViewModel.swift */; };
+		EE12EA132934AF2900D41DFE /* CustomCalendarCellProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12EA122934AF2900D41DFE /* CustomCalendarCellProtocol.swift */; };
 		EE2C553D291CC08B0018B109 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = EE2C553C291CC08B0018B109 /* SnapKit */; };
 		EE3E29A829235F6B007C7FC7 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E29A729235F6B007C7FC7 /* UITextField+.swift */; };
 		EE3E29BC2923C870007C7FC7 /* TravelAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3E29BB2923C870007C7FC7 /* TravelAddViewController.swift */; };
@@ -279,6 +281,8 @@
 		EE116C5B2924C9390017B519 /* TravelAddViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelAddViewModel.swift; sourceTree = "<group>"; };
 		EE116C5D2924CB6B0017B519 /* TravelAddViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelAddViewProtocol.swift; sourceTree = "<group>"; };
 		EE116C622924EC860017B519 /* PlanAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanAddViewController.swift; sourceTree = "<group>"; };
+		EE12EA102934AEFA00D41DFE /* CustomCalendarCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendarCellViewModel.swift; sourceTree = "<group>"; };
+		EE12EA122934AF2900D41DFE /* CustomCalendarCellProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendarCellProtocol.swift; sourceTree = "<group>"; };
 		EE3E29A729235F6B007C7FC7 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		EE3E29AB292361B5007C7FC7 /* CustomCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendar.swift; sourceTree = "<group>"; };
 		EE3E29AD292365C7007C7FC7 /* CustomCalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCalendarCell.swift; sourceTree = "<group>"; };
@@ -1011,6 +1015,8 @@
 				EE116C572924AA0D0017B519 /* CustomCalendar.swift */,
 				EEDB752E2925E8DD0069A7F5 /* CalendarViewController.swift */,
 				EEDB75302925F56D0069A7F5 /* CalendarProtocol.swift */,
+				EE12EA102934AEFA00D41DFE /* CustomCalendarCellViewModel.swift */,
+				EE12EA122934AF2900D41DFE /* CustomCalendarCellProtocol.swift */,
 			);
 			path = Calendar;
 			sourceTree = "<group>";
@@ -1277,6 +1283,7 @@
 				B5D64E76292E3B6C00E1CC81 /* DiaryDetailLocalRepository.swift in Sources */,
 				BB02B096292F2A4900FE11DA /* DiaryInfoViewModel.swift in Sources */,
 				BB6079B1292F3ECF00BF30C8 /* DiaryListCell.swift in Sources */,
+				EE12EA132934AF2900D41DFE /* CustomCalendarCellProtocol.swift in Sources */,
 				A4CC04D5292332C600BB678B /* UILabel+ChangeFontSize.swift in Sources */,
 				BB288FC8292E167900065D04 /* DiaryCalloutView.swift in Sources */,
 				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
@@ -1321,6 +1328,7 @@
 				BBDB2E922926222100752924 /* ExpenseInfoViewModel.swift in Sources */,
 				BBE695D629227C8D0015FAD4 /* TravelInfoViewModel.swift in Sources */,
 				A4CC04A829221EEE00BB678B /* Expense+CoreDataClass.swift in Sources */,
+				EE12EA112934AEFA00D41DFE /* CustomCalendarCellViewModel.swift in Sources */,
 				A4CC04E22923777B00BB678B /* NSObject+Name.swift in Sources */,
 				A4CC04D9292351D700BB678B /* PlanRepository.swift in Sources */,
 				B595A984292CE53100C3B897 /* ExpenseType.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -98,7 +98,11 @@ extension ExpenseAddViewController {
     }
     
     @objc func dateButtonTouchUpInside() {
-        let calendarViewController = CalendarViewController(touchOption: .single, type: .date)
+        guard let travel else { return }
+        let calendarViewController = CalendarViewController(
+            touchOption: .single, type: .date,
+            startDate: travel.startDate, endDate: travel.endDate
+        )
         calendarViewController.delegate = self
         present(calendarViewController, animated: true)
     }
@@ -130,7 +134,7 @@ extension ExpenseAddViewController {
               let travel = travel else {
             return
         }
-            
+        
         let expenseDTO = ExpenseDTO(
             name: name,
             category: category,
@@ -206,7 +210,7 @@ extension ExpenseAddViewController {
             name: UIResponder.keyboardWillHideNotification, object: nil
         )
     }
-  
+    
     @objc private func keyboardWillShow(notification: NSNotification) {
         guard let userInfo = notification.userInfo,
               let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
@@ -221,7 +225,7 @@ extension ExpenseAddViewController {
         )
         rootView.scrollView.contentInset = contentInsets
     }
-
+    
     @objc private func keyboardWillHide(notification: NSNotification) {
         rootView.scrollView.contentInset = .zero
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
@@ -171,11 +171,11 @@ final class PlanAddViewController: UIViewController {
     // MARK: - Properties
     
     private let viewModel: PlanAddViewModel
-    private let travel: Travel?
+    private let travel: Travel
     
     // MARK: - Lifecycles
     
-    init(travel: Travel?) {
+    init(travel: Travel) {
         viewModel = PlanAddViewModel()
         self.travel = travel
         super.init(nibName: nil, bundle: nil)
@@ -334,8 +334,12 @@ extension PlanAddViewController {
 
 extension PlanAddViewController {
     @objc func dateInputButtonTouchUpInside() {
-        let calendarViewController = CalendarViewController(touchOption: .single, type: .dateAndTime)
+        let calendarViewController = CalendarViewController(
+            touchOption: .single, type: .dateAndTime, startDate: travel.startDate, endDate: travel.endDate
+        )
+        print(travel)
         calendarViewController.delegate = self
+        
         present(calendarViewController, animated: true)
     }
     
@@ -356,8 +360,7 @@ extension PlanAddViewController {
                 dateString: dateString,
                 formatter: Date.yearMonthDayTimeDateFormatter
               ),
-              let content = descriptionTextView.text,
-              let travel = travel
+              let content = descriptionTextView.text
         else {
             return
         }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -66,7 +66,11 @@ final class PlanListViewController: UIViewController {
     private func configureNavigationBar() {
         navigationItem.title = viewModel.navigationTitle
         setRightBarAddButton { [weak self] in
-            PlanAddViewController(travel: self?.viewModel.travel)
+            if let travel = self?.viewModel.travel {
+                return PlanAddViewController(travel: travel)
+            } else {
+                return UIViewController()
+            }
         }
     }
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -144,8 +144,8 @@ final class TravelAddViewController: UIViewController {
         customCalendar.completionHandler = { [weak self] dates in
             self?.viewModel.travelDateTapped(dates: dates) { isSuccess in
                 if isSuccess {
-                    self?.travelDateStartLabel.text = dates[0]
-                    self?.travelDateEndLabel.text = dates[1]
+                    self?.travelDateStartLabel.text = Date.yearMonthDayDateFormatter.string(from: dates[0])
+                    self?.travelDateEndLabel.text = Date.yearMonthDayDateFormatter.string(from: dates[1])
                 } else {
                     self?.presentErrorAlert(title: "날짜를 다시 입력해주세요")
                 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewProtocol.swift
@@ -15,7 +15,7 @@ protocol TravelAddViewProtocol: AnyObject {
     var isValidInput: Bool { get set }
     
     func travelTitleDidChanged(title: String?)
-    func travelDateTapped(dates: [String], completion: @escaping ((Bool) -> Void))
+    func travelDateTapped(dates: [Date], completion: @escaping ((Bool) -> Void))
     
     func postTravel(travel: TravelDTO, completion: @escaping (() -> Void))
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
@@ -41,7 +41,7 @@ final class TravelAddViewModel: TravelAddViewProtocol {
     }
     
     
-    func travelDateTapped(dates: [String], completion: @escaping ((Bool) -> Void)) {
+    func travelDateTapped(dates: [Date], completion: @escaping ((Bool) -> Void)) {
         defer {
             isValidInput = isValidTextField && isValidDate
             completion(isValidDate)

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CalendarViewController.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CalendarViewController.swift
@@ -74,7 +74,7 @@ final class CalendarViewController: UIViewController, CalendarProtocol {
     // MARK: - Properties
     
     weak var delegate: CalendarViewDelegate?
-    private var date: String?
+    private var date: Date?
     private let touchOption: CustomCalendar.TouchOption
     private let type: CustomCalendar.CalendarType
     private let dateFormatter = Date.timeDateFormatter
@@ -145,9 +145,9 @@ extension CalendarViewController {
         }
         if type == .dateAndTime {
             let time = dateFormatter.string(from: timeDatepicker.date)
-            let dateString = "\(date) \(time)"
+            let dateString = "\(Date.yearMonthDayDateFormatter.string(from: date)) \(time)"
             delegate?.fetchDate(dateString: dateString)
-        } else { delegate?.fetchDate(dateString: date) }
+        } else { delegate?.fetchDate(dateString: Date.yearMonthDayDateFormatter.string(from: date)) }
         dismiss(animated: true)
             
     }

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CalendarViewController.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CalendarViewController.swift
@@ -33,9 +33,10 @@ final class CalendarViewController: UIViewController, CalendarProtocol {
         let calendar = CustomCalendar(
             frame: .zero,
             collectionViewLayout: CustomCalendar.createLayout(),
-            touchOption: touchOption
+            touchOption: touchOption,
+            startDate: startDate,
+            endDate: endDate
         )
-        
         calendar.completionHandler = { [weak self] dates in
             guard let self, dates.count == 1 else { return }
             switch self.touchOption {
@@ -78,13 +79,21 @@ final class CalendarViewController: UIViewController, CalendarProtocol {
     private let touchOption: CustomCalendar.TouchOption
     private let type: CustomCalendar.CalendarType
     private let dateFormatter = Date.timeDateFormatter
-    
+    private let startDate: Date?
+    private let endDate: Date?
     
     // MARK: - Lifecycles
     
-    init(touchOption: CustomCalendar.TouchOption, type: CustomCalendar.CalendarType) {
+    init(
+        touchOption: CustomCalendar.TouchOption,
+        type: CustomCalendar.CalendarType,
+        startDate: Date? = nil,
+        endDate: Date? = nil
+    ) {
         self.touchOption = touchOption
         self.type = type
+        self.startDate = startDate
+        self.endDate = endDate
         super.init(nibName: nil, bundle: nil)
     }
     

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
@@ -221,7 +221,9 @@ extension CustomCalendar {
                     let date = "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
                     if let selectedDate = selectedDates.first {
                         let isSelectable = selectedDate <= date
-                        days.append(Item(day: "\(day - firstWeekIndex + 1)", isSelectable: isSelectable))
+                        days.append(Item(day: "\(day - firstWeekIndex + 1)",
+                                         isSelected: selectedDate == date,
+                                         isSelectable: isSelectable))
                     } else {
                         days.append(Item(day: "\(day - firstWeekIndex + 1)", isSelectable: true))
                     }
@@ -272,13 +274,13 @@ extension CustomCalendar: UICollectionViewDelegate {
                         print("\(currentYear)년 \(currentMonth)월 \(currentDay)일")
                     }
                 }
-                print(days)
             } else if selectedCount == 2 {
                 completionHandler?(selectedDates)
                 selectedDates.removeAll()
                 selectedCount = 0
                 for index in 0..<days.count {
                     days[index].isSelected = false
+                    days[index].isSelectable = true
                 }
             }
             configureSnapshot()

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
@@ -17,7 +17,7 @@ final class CustomCalendar: UICollectionView {
     
     struct Item: Hashable {
         let id = UUID()
-        let day: String
+        let date: Date?
         var isSelected: Bool = false
         var isSelectable: Bool = true
     }
@@ -38,9 +38,9 @@ final class CustomCalendar: UICollectionView {
     private var days: [Item] = []
     private let touchOption: TouchOption
     private var selectedCount = 0
-    private var selectedDates: [String] = []
+    private var selectedDates: [Date] = []
     
-    var completionHandler: (([String]) -> Void)?
+    var completionHandler: (([Date]) -> Void)?
     
     // MARK: - Lifecycles
     
@@ -179,15 +179,7 @@ final class CustomCalendar: UICollectionView {
         
         days.removeAll()
         
-        /// 첫번째 날짜가 시작할 때 부터 숫자를 채워줌, 이전 날짜는 공백으로 처리
         setSelectableDay(firstWeekIndex: firstWeekIndex, totalDays: totalDays)
-//        for day in 0..<totalDays {
-//            if day < firstWeekIndex {
-//                days.append(Item(day: ""))
-//            } else {
-//                days.append(Item(day: "\(day - firstWeekIndex + 1)"))
-//            }
-//        }
         
     }
 }
@@ -203,6 +195,10 @@ extension CustomCalendar {
         case dateAndTime
     }
     
+    /// 첫번째 날짜가 시작할 때 부터 숫자를 채워줌, 이전 날짜는 공백으로 처리
+    /// - Parameters:
+    ///   - firstWeekIndex: 현재 달의 1일의 요일 월요일(0)
+    ///   - totalDays: 모든 날짜의 합
     private func setSelectableDay(firstWeekIndex: Int, totalDays: Int) {
         switch touchOption {
         case .single:
@@ -215,17 +211,21 @@ extension CustomCalendar {
             let currentMonth = String(format: "%02d", month)
             for day in 0..<totalDays {
                 if day < firstWeekIndex {
-                    days.append(Item(day: ""))
+                    days.append(Item(date: nil, isSelectable: false))
                 } else {
                     let currentDay = String(format: "%02d", day - firstWeekIndex + 1)
-                    let date = "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
+                    let stringDate = "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
+                    guard let date = Date.yearMonthDayDateFormatter.date(from: stringDate) else {
+                        return
+                    }
                     if let selectedDate = selectedDates.first {
                         let isSelectable = selectedDate <= date
-                        days.append(Item(day: "\(day - firstWeekIndex + 1)",
+                        days.append(Item(date: date,
                                          isSelected: selectedDate == date,
                                          isSelectable: isSelectable))
                     } else {
-                        days.append(Item(day: "\(day - firstWeekIndex + 1)", isSelectable: true))
+                        days.append(Item(date: date,
+                                         isSelectable: true))
                     }
                     
                 }
@@ -249,10 +249,11 @@ extension CustomCalendar: UICollectionViewDelegate {
         
         let currentMonth = String(format: "%02d", month)
         let currentDay = String(format: "%02d", indexPath.row - startDay + 1)
-        let date = "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
+        let stringDate = "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
         days[indexPath.row].isSelected.toggle()
         selectedCount += 1
         
+        guard let date = Date.yearMonthDayDateFormatter.date(from: stringDate) else { return }
         selectedDates.append(date)
         
         switch touchOption {
@@ -261,27 +262,21 @@ extension CustomCalendar: UICollectionViewDelegate {
             selectedDates.removeAll()
             selectedCount = 0
             configureSnapshot()
-            for index in 0..<days.count {
-                days[index].isSelected = false
-            }
+            days = days.map { Item(date: $0.date, isSelected: false, isSelectable: $0.isSelectable) }
         case .double:
             if selectedCount == 1 {
                 if let selectedDate = selectedDates.first {
-                    for index in 0..<days.count {
-                        let currentDay = days[index].day.count == 1 ? "0" + days[index].day : days[index].day
-                        days[index].isSelectable = selectedDate
-                        <= "\(currentYear)년 \(currentMonth)월 \(currentDay)일"
-                        print("\(currentYear)년 \(currentMonth)월 \(currentDay)일")
+                    days = days.map {
+                        $0.date == nil ? Item(date: nil, isSelectable: false)
+                        : Item(date: $0.date ?? Date(), isSelected: selectedDate == ($0.date ?? Date()),
+                               isSelectable: selectedDate <= ($0.date ?? Date()))
                     }
                 }
             } else if selectedCount == 2 {
                 completionHandler?(selectedDates)
                 selectedDates.removeAll()
                 selectedCount = 0
-                for index in 0..<days.count {
-                    days[index].isSelected = false
-                    days[index].isSelectable = true
-                }
+                days = days.map { Item(date: $0.date, isSelected: false, isSelectable: true)}
             }
             configureSnapshot()
         }

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
@@ -53,5 +53,6 @@ final class CustomCalendarCell: UICollectionViewCell {
     func configureUI(item: CustomCalendar.Item) {
         dateLabel.text = item.day
         dateLabel.layer.borderWidth = item.isSelected ? 1 : 0
+        dateLabel.textColor = item.isSelectable ? .primaryOrange : .gray
     }
 }

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
@@ -27,12 +27,15 @@ final class CustomCalendarCell: UICollectionViewCell {
     // MARK: - Properties
     
     static let identifier = "CustomCalendarCell"
+    private let viewModel: CustomCalendarCellViewModel
     
     // MARK: - Lifecycles
     
     override init(frame: CGRect) {
+        viewModel = CustomCalendarCellViewModel()
         super.init(frame: frame)
         configureViews()
+        viewModel.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -53,10 +56,20 @@ final class CustomCalendarCell: UICollectionViewCell {
     func configureUI(item: CustomCalendar.Item) {
         if let date = item.date {
             dateLabel.text = Date.onlyDayDateFormaater.string(from: date)
+            viewModel.checkDateIsSunday(to: date)
         } else {
             dateLabel.text = ""
         }
         dateLabel.layer.borderWidth = item.isSelected ? 1 : 0
-        dateLabel.textColor = item.isSelectable ? .primaryOrange : .gray
+        if !item.isSelectable {
+            dateLabel.textColor = .grey1
+        }
+    }
+    
+}
+
+extension CustomCalendarCell: CustomCalendarCellDelegate {
+    func changeLabelColor(isSunday: Bool) {
+        dateLabel.textColor = isSunday ? .systemRed : .black
     }
 }

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCell.swift
@@ -51,7 +51,11 @@ final class CustomCalendarCell: UICollectionViewCell {
     }
     
     func configureUI(item: CustomCalendar.Item) {
-        dateLabel.text = item.day
+        if let date = item.date {
+            dateLabel.text = Date.onlyDayDateFormaater.string(from: date)
+        } else {
+            dateLabel.text = ""
+        }
         dateLabel.layer.borderWidth = item.isSelected ? 1 : 0
         dateLabel.textColor = item.isSelectable ? .primaryOrange : .gray
     }

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellProtocol.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  CustomCalendarCellProtocol.swift
+//  Doesaegim
+//
+//  Created by 김민석 on 2022/11/28.
+//
+
+import Foundation
+
+protocol CustomCalendarCellProtocol: AnyObject {
+    var delegate: CustomCalendarCellDelegate? { get set }
+    var isSunday: Bool { get set }
+    
+    func checkDateIsSunday(to date: Date)
+}
+
+protocol CustomCalendarCellDelegate: AnyObject {
+    func changeLabelColor(isSunday: Bool)
+}

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellViewModel.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  CustomCalendarCellViewModel.swift
+//  Doesaegim
+//
+//  Created by 김민석 on 2022/11/28.
+//
+
+import Foundation
+
+final class CustomCalendarCellViewModel: CustomCalendarCellProtocol {
+    weak var delegate: CustomCalendarCellDelegate?
+    
+    var isSunday: Bool {
+        didSet {
+            delegate?.changeLabelColor(isSunday: isSunday)
+        }
+    }
+    
+    init() {
+        self.isSunday = false
+    }
+    
+    
+    func checkDateIsSunday(to date: Date) {
+        let calendar = Calendar.current
+        let week = calendar.component(.weekday, from: date)
+        isSunday = week == 2
+    }
+    
+}

--- a/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+TravelString.swift
@@ -60,6 +60,12 @@ extension Date {
         return formatter
     }()
     
+    static let onlyDayDateFormaater: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d"
+        return formatter
+    }()
+    
     /// 시작일 Date인스턴스와 종료일 Date 인스턴스를 받아 여행 목록시 부제목으로 사용되는 문자열을 반환한다.
     /// - Parameters:
     ///   - start: 시작일 `Date`인스턴스


### PR DESCRIPTION
## 변경사항
* 여행을 추가할 때, 출발 날짜를 선택하면 출발 날짜 이전은 선택하지 못하도록 구현했습니다.
* 일요일일 때, label Color를 수정했습니다.
* Cell에 String 자료형으로 일자만 갖고있었는데, Date() 자료형으로 수정하였습니다.
* 일정 및 지출 추가시 여행날짜에 포함되지 않으면 선택하지 못하도록 수정하였습니다.
* 선택 못하는 날짜의 색상을 변경하였습니다.

## 리뷰노트
* Cell에서 원래 "1", "2" 와 같이 일자만 들고있고, 달력에서 연도와 달을 가져오는 식으로 구현을 했는데, Date() 형식으로 연도, 달, 날짜 까지 갖고있는데 더 좋다고 생각해서 변경하였습니다.
* 일요일인지 판별하는 것을 Cell에서 해주는 게 맞을지 고민이 됐습니다. ViewController와 ViewModel 처럼 Cell도 CellViewModel을 만들어서 구현을 하였는데, 그냥 Cell에서 해줘도 될지..? 의견이 궁금합니다!

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-28 at 20 08 42](https://user-images.githubusercontent.com/77199797/204263317-5f0aff90-955b-41e4-b1cf-8707e447e13d.gif)

