### PR TITLE
[리팩토링 및 버그 수정] 다이어리 조회, 그래프 이슈 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -115,7 +115,9 @@ final class DiaryDetailView: UIView {
     func setupData(diary: Diary) {
         contentLabel.text = diary.content
         locationLabel.text = diary.location?.name
-        dateLabel.text = diary.date?.description
+        
+        let dateFormatter = Date.yearMonthDayTimeDateFormatter
+        dateLabel.text = dateFormatter.string(from: diary.date ?? Date())
     }
     
     func setupNumberOfPages(_ count: Int) {
@@ -124,6 +126,10 @@ final class DiaryDetailView: UIView {
     
     func setupCurrentPage(_ pageIndex: Int) {
         pageControl.currentPage = pageIndex
+    }
+    
+    func setupImageSliderShowing(with isHidden: Bool) {
+        imageSlider.isHidden = isHidden
     }
     
     // MARK: - Configure Functions

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -61,7 +61,9 @@ final class DiaryDetailViewController: UIViewController {
         super.viewDidLoad()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         guard isInitializedViewModel() else {
             presentErrorAlert(title: "다이어리 정보를 찾을 수 없습니다.", handler: { [weak self] _ in
                 self?.viewModelDidNotInitialized()

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -59,11 +59,12 @@ final class DiaryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
         guard isInitializedViewModel() else {
             presentErrorAlert(title: "다이어리 정보를 찾을 수 없습니다.", handler: { [weak self] _ in
-                // FIXME: 모달창으로 띄워진다면? 사라지지 않음...
-                self?.navigationController?.popViewController(animated: true)
+                self?.viewModelDidNotInitialized()
             })
             return
         }
@@ -75,8 +76,16 @@ final class DiaryDetailViewController: UIViewController {
     // MARK: - Configure Functions
     
     private func isInitializedViewModel() -> Bool {
-        guard viewModel != nil else { return false }
-        return true
+        return viewModel != nil
+    }
+    
+    /// 뷰모델이 이니셜라이징 되지 않았을 경우 해당 뷰를 pop 또는 dismiss 처리한다.
+    private func viewModelDidNotInitialized() {
+        if let navigationController = navigationController {
+            navigationController.popViewController(animated: true)
+            return
+        }
+        dismiss(animated: true)
     }
     
     private func bindToViewModel() {
@@ -126,6 +135,7 @@ final class DiaryDetailViewController: UIViewController {
         snapshot.appendItems(viewModel.cellViewModels)
         
         imageSliderDataSource?.apply(snapshot)
+        rootView.setupImageSliderShowing(with: viewModel.cellViewModels.isEmpty)
     }
 }
 

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
@@ -12,7 +12,7 @@ struct CustomChartItem {
     let category: ExpenseType
     
     /// 차트 데이터 값
-    let value: CGFloat
+    var value: CGFloat
     
     init(category: ExpenseType, value: CGFloat) {
         self.category = category


### PR DESCRIPTION
## 변경사항
### 지출 그래프
- 지출 그래프의 카테고리 별로 데이터가 합쳐서 표시되도록 수정했습니다.
  - 그래프 애니메이션과 함께 올리려고 했던 커밋이지만 늦어질 것 같아 미리 올립니다..!

### 다이어리 조회
- 다이어리 이미지 목록이 빈배열일 경우 이미지뷰를 히든 처리하도록 수정했습니다.
- 모달창 또는 내비게이션으로 해당 뷰가 푸시되었을 때 모두 빠져나올 수 있도록 처리하는 메서드를 구현했습니다.
- 다이어리 날짜 표시를 단순 description 처리해놓았었는데 DateFormatter를 적용하도록 수정했습니다.

## 관련 이슈
- resolves #104 

## 리뷰노트
- 코멘트로 남기겠습니다!

## 스크린샷
present로 상세 화면을 띄울 때 나타나는 alert 스크린샷 입니다!!

https://user-images.githubusercontent.com/50136980/204451540-7546d38f-5865-4ba7-ac0b-92fa105524c6.mp4
