### PR TITLE
[다이어리 작성] 여행 피커 순서를 종료 날짜 최신순으로 변경 #53

### DIFF
--- a/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAdd/DiaryAddLocalRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/DiaryScene/DiaryAdd/DiaryAddLocalRepository.swift
@@ -18,7 +18,7 @@ struct DiaryAddLocalRepository: DiaryAddRepository {
     // MARK: - Functions
 
     func fetchAllTravels() -> Result<[Travel], Error> {
-        let request = Travel.fetchRequest()
+        let request = Travel.endDateSortedFetchRequest()
         request.fetchBatchSize = Metric.fetchBatchSize
 
         return persistentManager.fetch(request: request)

--- a/Doesaegim/NSManagedObjectClass/Plan+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Plan+CoreDataClass.swift
@@ -51,7 +51,7 @@ public class Plan: NSManagedObject {
         return request
     }
 
-    /// 특정 Travel 엔티티의 모든 Plan을 호출하는 리퀘스트로 순서를 지정하지 않으면 (오래된) 날짜 순서로 정렬
+    /// 특정 Travel 엔티티의 모든 Plan을 호출하는 리퀘스트로 순서를 지정하지 않으면 (최신) 날짜 순서로 정렬
     static func fetchRequest(
         travelID: UUID,
         sortDescriptors: [NSSortDescriptor] = [.init(key: "date", ascending: false)]

--- a/Doesaegim/NSManagedObjectClass/Travel+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Travel+CoreDataClass.swift
@@ -52,4 +52,24 @@ public class Travel: NSManagedObject {
         
         return travelInfo
     }
+
+
+    // MARK: - Fetch Request Functions
+
+    /// 모든 Travel 엔티티를 가져옴
+    static func fetchRequest(
+        predicate: NSPredicate?,
+        sortDescriptors: [NSSortDescriptor]?
+    ) -> NSFetchRequest<Travel> {
+
+        let request = NSFetchRequest<Travel>(entityName: Travel.name)
+        request.predicate = predicate
+        request.sortDescriptors = sortDescriptors
+        return request
+    }
+
+    /// 특정 Travel 엔티티의 모든 Plan을 호출하는 리퀘스트로 순서를 지정하지 않으면 종료 날짜 최신순으로로 정렬
+    static func endDateSortedFetchRequest() -> NSFetchRequest<Travel> {
+        fetchRequest(predicate: nil, sortDescriptors: [NSSortDescriptor(key: "endDate", ascending: false)])
+    }
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- resolves #53 
- 유저 편의를 위해 여행 피커에 종료 날짜가 현재에 가까운 순서대로 뜨도록 변경했습니다. 

## 리뷰노트
> 고민, 과정, 궁금한점

## 스크린샷
<img src = "https://user-images.githubusercontent.com/81314063/204478695-c59606b5-4726-46bc-a6c7-41fd4bd5d49d.png" width="200">