### PR TITLE
[커스텀 그래프] 원형 그래프 애니메이션 구현

### DIFF
--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -84,9 +84,9 @@ final class CustomPieChart: UIView {
         )
         layer.addSublayer(pieceLayer)
         
-        guard let boundingBox = pieceLayer.path?.boundingBox
-        else { return }
+        guard let boundingBox = pieceLayer.path?.boundingBox else { return }
         let textLayer = PieceTextLayer(
+            center: CGPoint(x: rect.width/2, y: rect.height/2),
             pieceBounds: boundingBox,
             text: "\(item.category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
         )

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -22,6 +22,16 @@ final class CustomPieChart: UIView {
         items.reduce(0) { $0 + $1.value }
     }
     
+    // MARK: - Animation Properties
+    
+    private var startAngle: CGFloat = Metric.initialStartAngle
+    
+    private var currentIndex = 0
+    
+    private var currentItem: CustomChartItem { items[currentIndex] }
+    
+    private var ratio: CGFloat { currentItem.value / total }
+    
     // MARK: - Init
     
     /// 원형 차트를 그릴 기반이 되는 데이터 값의 배열을 받아 차트 화면을 생성한다.
@@ -41,10 +51,9 @@ final class CustomPieChart: UIView {
         configureBackgroundColor()
     }
     
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        
-        configureBackgroundColor()
     }
     
     // MARK: - Draw Functions
@@ -52,34 +61,41 @@ final class CustomPieChart: UIView {
     /// 주어진 rect에 맞게 원형 차트를 그린다. 원형 차트는 정원 형태로 영역에 꽉 채워서 그려진다.
     /// - Parameter rect: 원형 차트를 그릴 영역.
     override func draw(_ rect: CGRect) {
-        var startAngle: CGFloat = Metric.initialStartAngle
+        if isAnimating {
+            drawOnePiece(with: currentItem, on: rect)
+            return
+        }
         
-        for item in items {
-            let ratio: CGFloat = item.value / total
-            let angleRatio = ratio * Metric.angle
-            
-            let pieceLayer = PieceShapeLayer(
-                rect: rect,
-                startAngle: startAngle,
-                angleRatio: angleRatio,
-                color: item.category.color.cgColor
-            )
-            if isAnimating {
-                let pieceAnimation = configureLayerAnimation()
-                pieceLayer.add(pieceAnimation, forKey: pieceAnimation.keyPath)
-            }
-            layer.addSublayer(pieceLayer)
-            
-            guard let boundingBox = pieceLayer.path?.boundingBox else { continue }
-            let textLayer = PieceTextLayer(
-                pieceBounds: boundingBox,
-                text: "\(item.category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
-            )
-            layer.addSublayer(textLayer)
-            
-            startAngle += angleRatio
+        initializeAnimation()
+        for index in items.indices {
+            currentIndex = index
+            drawOnePiece(with: currentItem, on: rect)
+            startAngle += ratio * Metric.angle
         }
 
+    }
+    
+    private func drawOnePiece(with item: CustomChartItem, on rect: CGRect) {
+        let pieceLayer = PieceShapeLayer(
+            rect: rect,
+            startAngle: startAngle,
+            angleRatio: ratio * Metric.angle,
+            color: item.category.color.cgColor
+        )
+        layer.addSublayer(pieceLayer)
+        
+        guard let boundingBox = pieceLayer.path?.boundingBox
+        else { return }
+        let textLayer = PieceTextLayer(
+            pieceBounds: boundingBox,
+            text: "\(item.category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
+        )
+        layer.addSublayer(textLayer)
+        
+        if isAnimating {
+            let pieceAnimation = configureLayerAnimation()
+            pieceLayer.add(pieceAnimation, forKey: pieceAnimation.keyPath)
+        }
     }
     
     // MARK: - Configure Functions
@@ -94,7 +110,8 @@ final class CustomPieChart: UIView {
         let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
         animation.fromValue = Metric.animationFromValue
         animation.toValue = Metric.animationToValue
-        animation.duration = Metric.animationDuration
+        animation.duration = ratio * Metric.animationDuration
+        animation.delegate = self
         
         return animation
     }
@@ -106,9 +123,28 @@ final class CustomPieChart: UIView {
     func setupData(with data: [CustomChartItem]) {
         self.items = data
         self.isAnimating = !data.isEmpty
+        initializeAnimation()
+        
         setNeedsDisplay()
     }
     
+    private func initializeAnimation() {
+        startAngle = Metric.initialStartAngle
+        currentIndex = 0
+    }
+    
+}
+
+// MARK: - CAAnimationDelegate
+
+extension CustomPieChart: CAAnimationDelegate {
+    func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
+        guard flag, currentIndex < items.count - 1 else { return }
+        
+        startAngle += ratio * Metric.angle
+        currentIndex += 1
+        setNeedsDisplay()
+    }
 }
 
 // MARK: - Namespaces
@@ -120,7 +156,7 @@ extension CustomPieChart {
         
         static let animationFromValue: CGFloat = 0
         static let animationToValue: CGFloat = 1
-        static let animationDuration: CGFloat = 1.3
+        static let animationDuration: CGFloat = 1.2
     }
     
     enum StringLiteral {

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -16,6 +16,8 @@ final class CustomPieChart: UIView {
     
     private var items: [CustomChartItem] = []
     
+    private var isAnimating: Bool = false
+    
     private var total: CGFloat {
         items.reduce(0) { $0 + $1.value }
     }
@@ -24,7 +26,7 @@ final class CustomPieChart: UIView {
     
     /// 원형 차트를 그릴 기반이 되는 데이터 값의 배열을 받아 차트 화면을 생성한다.
     /// - Parameters:
-    ///   - data: 차트 데이터 값의 배열 (추후 카테고리 정보를 함께 받아 색도 함께 지정해줘야함)
+    ///   - data: 차트 데이터 값의 배열
     convenience init(
         items: [CustomChartItem],
         frame: CGRect = .zero
@@ -62,6 +64,10 @@ final class CustomPieChart: UIView {
                 angleRatio: angleRatio,
                 color: item.category.color.cgColor
             )
+            if isAnimating {
+                let pieceAnimation = configureLayerAnimation()
+                pieceLayer.add(pieceAnimation, forKey: pieceAnimation.keyPath)
+            }
             layer.addSublayer(pieceLayer)
             
             guard let boundingBox = pieceLayer.path?.boundingBox else { continue }
@@ -83,12 +89,23 @@ final class CustomPieChart: UIView {
         backgroundColor = .white
     }
     
+    /// 파이 조각별 애니메이션 설정
+    private func configureLayerAnimation() -> CABasicAnimation {
+        let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
+        animation.fromValue = Metric.animationFromValue
+        animation.toValue = Metric.animationToValue
+        animation.duration = Metric.animationDuration
+        
+        return animation
+    }
+    
     // MARK: - Setup Data & Redraw Functions
     
     /// 차트를 표시하는 데이터를 변경할 경우 실행하는 메서드. 데이터를 설정하고 차트를 다시 그린다.
     /// - Parameter data: 변경할 차트 데이터
     func setupData(with data: [CustomChartItem]) {
         self.items = data
+        self.isAnimating = !data.isEmpty
         setNeedsDisplay()
     }
     
@@ -100,5 +117,13 @@ extension CustomPieChart {
     enum Metric {
         static let initialStartAngle: CGFloat = (.pi) * 3 / 2
         static let angle: CGFloat = .pi * 2
+        
+        static let animationFromValue: CGFloat = 0
+        static let animationToValue: CGFloat = 1
+        static let animationDuration: CGFloat = 1.3
+    }
+    
+    enum StringLiteral {
+        static let animationKey = "strokeEnd"
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceShapeLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceShapeLayer.swift
@@ -47,7 +47,6 @@ final class PieceShapeLayer: CAShapeLayer {
         
         configurePath()
         configureAttributes()
-        configureAnimation()
     }
     
     @available(*, unavailable)
@@ -78,16 +77,6 @@ final class PieceShapeLayer: CAShapeLayer {
         strokeColor = color
         fillColor = UIColor.clear.cgColor
     }
-    
-    /// 애니메이션을 설정한다.
-    private func configureAnimation() {
-        let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
-        animation.fromValue = Metric.animationFromValue
-        animation.toValue = Metric.animationToValue
-        animation.duration = Metric.animationDuration
-        
-        add(animation, forKey: animation.keyPath)
-    }
 }
 
 // MARK: - Namespaces
@@ -96,13 +85,5 @@ extension PieceShapeLayer {
     enum Metric {
         static let spacing: CGFloat = 5
         static let radiusRatio: CGFloat = 0.23
-        
-        static let animationFromValue: CGFloat = 0
-        static let animationToValue: CGFloat = 1
-        static let animationDuration: CGFloat = 1.3
-    }
-    
-    enum StringLiteral {
-        static let animationKey = "strokeEnd"
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
@@ -11,13 +11,19 @@ final class PieceTextLayer: CATextLayer {
     
     // MARK: - Properties
     
+    /// 파이 차트의 중심값
+    private let center: CGPoint
+    
+    /// 파이 조각이 그려진 영역 값
     private let pieceBounds: CGRect
     
+    /// 파이 조각에 표시할 텍스트
     private let text: String
     
     // MARK: - Init
     
-    init(pieceBounds: CGRect, text: String) {
+    init(center: CGPoint, pieceBounds: CGRect, text: String) {
+        self.center = center
         self.pieceBounds = pieceBounds
         self.text = text
         
@@ -35,26 +41,70 @@ final class PieceTextLayer: CATextLayer {
     
     // MARK: - Configure Functions
     
+    /// 표시할 텍스트 레이어의 위치, 크기를 지정한다.
     private func configureFrame() {
+        let spacing = CGPoint(
+            x: pieceBounds.width * 0.1,
+            y: pieceBounds.height * 0.1
+        )
+        let xPosition = configureXPosition(with: spacing.x)
+        let yPosition = configureYPosition(with: spacing.y)
+        
         let textFrame = CGRect(
-            x: pieceBounds.minX + pieceBounds.width * 0.15,
-            y: pieceBounds.minY + pieceBounds.height * 0.25,
-            width: pieceBounds.width/1.5,
-            height: pieceBounds.height/2
+            x: xPosition,
+            y: yPosition,
+            width: Metric.textWidth,
+            height: fontSize * 2
         )
         frame = textFrame
     }
     
+    /// 표시할 텍스트의 크기, 색상을 지정한다.
     private func configureText() {
-        string = text
-        fontSize = Metric.textFontSize
-        alignmentMode = .center
-        foregroundColor = UIColor.white?.cgColor
+        let attributedString = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: UIFont.boldSystemFont(ofSize: Metric.textFontSize),
+                .foregroundColor: UIColor.white ?? UIColor()
+            ]
+        )
+        string = attributedString
+        alignmentMode = .left
+    }
+    
+    // TODO: configureXPosition, configureYPosition 겹치는 부분 합치고 싶은데 가능할까..
+    
+    /// 텍스트가 표시될 위치의 x 좌표 값을 구해 반환한다.
+    /// - Parameter spacing: 파이 차트 중심에서 떨어질 정도 값
+    /// - Returns: 텍스트가 표시될 x 좌표 값
+    private func configureXPosition(with spacing: CGFloat) -> CGFloat {
+        let leftSide: CGFloat = abs(center.x - pieceBounds.minX)
+        let rightSide: CGFloat = abs(center.x - pieceBounds.maxX)
+        
+        let baseXPosition = leftSide < rightSide ? pieceBounds.midX : pieceBounds.minX
+        let multiplier: CGFloat = leftSide < rightSide ? 1 : -1
+        
+        return baseXPosition + multiplier * spacing
+    }
+    
+    /// 텍스트가 표시될 위치의 y 좌표 값을 구해 반환한다.
+    /// - Parameter spacing: 파이 차트 중심에서 떨어질 정도 값
+    /// - Returns: 텍스트가 표시될 y 좌표 값
+    private func configureYPosition(with spacing: CGFloat) -> CGFloat {
+        let topSide: CGFloat = abs(center.y - pieceBounds.minY)
+        let bottomSide: CGFloat = abs(center.y - pieceBounds.maxY)
+        
+        let baseYPosition = topSide < bottomSide ? pieceBounds.midY : pieceBounds.minY
+        let multiplier: CGFloat = topSide < bottomSide ? -1 : 1
+        print(multiplier)
+        
+        return baseYPosition + multiplier * spacing
     }
 }
 
 extension PieceTextLayer {
     enum Metric {
+        static let textWidth: CGFloat = 60
         static let textFontSize: CGFloat = 16
     }
 }


### PR DESCRIPTION
## 변경사항
- 원형 그래프의 애니메이션을 구현했습니다.
  - 지출 데이터가 있을 경우에만 애니메이션이 실행되며, 시계 방향으로 순차적으로 동작합니다.
- 원형 그래프에 표시되는 텍스트의 위치를 조정했습니다.

## 관련 이슈
- #102 

## 리뷰노트
- 애니메이션 구현을 위해 CABasicAnimation의 keyPath를 커스텀 해야할 뻔 했지만 기존에 주어진 keyPath를 최대한 활용해 해결할 수 있었습니다.
  - keyPath 중 선을 그리는 애니메이션을 설정할 수 있는 `strokeEnd`를 활용하였고, lineWidth를 원형 차트의 반지름만큼 키워 파이 조각의 면이 채워지는 듯한 효과를 주었습니다.
- 원형 차트의 파이 조각들을 시계 방향 순서로 차례대로 표시하는 과정에서 고민이 많았습니다.
  - 이전 파이 조각의 애니메이션이 언제 끝나는 지 확인이 필요해서 `CAAnimationDelegate`를 채택 받아 애니메이션이 끝나는 지점에 다음 파이 조각의 애니메이션이 시작될 것임을 저장하고, setNeedsDisplay()를 실행하여 draw 메서드가 재실행되도록 했습니다.
  - 블러 처리되어 있는 경우 애니메이션이 동작하지 않도록 해야했기에 isAnimating 프로퍼티를 별도로 선언해서 draw 메서드 내부에서 분기처리 해두었습니다.
- 텍스트 위치의 경우 텍스트를 표시할 파이 조각이 원형 차트의 중심을 기준으로 왼쪽과 오른쪽 중 어디에 위치해 있는지 계산해 x좌표를 구하도록 했고, y좌표도 마찬가지로 파이 조각이 위와 아래 중 어디에 위치하고 있는지 계산해 값을 조정했습니다.

## 스크린샷

https://user-images.githubusercontent.com/50136980/204601921-2beca4d7-63f9-4e81-8a7d-6f512d35c855.mp4

