### PR TITLE
[다이어리 목록] 다이어리 목록 버그 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
@@ -10,8 +10,8 @@ import Foundation
 protocol DiaryListViewModelProtocol: AnyObject {
     
     var delegate: DiaryListViewModelDelegate? { get set }
+    var travelSections: [String] { get set }
     var diaryInfos: [DiaryInfoViewModel] { get set }
-    var idAndTravelDictionary: [UUID: String] { get set }
     
     func fetchDiary()
     func addDummyDiaryData() // 추후 삭제

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
@@ -12,6 +12,7 @@ protocol DiaryListViewModelProtocol: AnyObject {
     var delegate: DiaryListViewModelDelegate? { get set }
     var travelSections: [String] { get set }
     var diaryInfos: [DiaryInfoViewModel] { get set }
+    var sectionDiaryDictionary: [Int: [DiaryInfoViewModel]] { get set }
     
     func fetchDiary()
     func addDummyDiaryData() // 추후 삭제

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListCell.swift
@@ -64,6 +64,7 @@ final class DiaryListCell: UICollectionViewCell {
     
     let thumbnailImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = 10
         

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListHeaderView.swift
@@ -38,6 +38,10 @@ final class DiaryListHeaderView: UICollectionReusableView {
         configure()
     }
     
+    override func prepareForReuse() {
+        headerLabel.text = ""
+    }
+    
 }
 
 extension DiaryListHeaderView {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListViewController.swift
@@ -200,9 +200,14 @@ extension DiaryListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: - 다이어리 선택 뷰, safe index 설정
         guard let viewModel = viewModel,
-              indexPath.row < viewModel.diaryInfos.count else { return }
-        let uuid = viewModel.diaryInfos[indexPath.row].id
+              indexPath.row < viewModel.diaryInfos.count,
+              let diary = viewModel.sectionDiaryDictionary[indexPath.section] else { return }
+        
         // uuid를 생성자에 넘기고 다이어리 디테일 뷰 푸시
+        let section = indexPath.section
+        let row = indexPath.row
+        let uuid = diary[row].id
+        
         let controller = DiaryDetailViewController(id: uuid)
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -16,13 +16,13 @@ final class DiaryListViewModel: DiaryListViewModelProtocol {
             delegate?.diaryInfoDidChage()
         }
     }
-//    var idAndTravelDictionary: [UUID: String]
+    var sectionDiaryDictionary: [Int: [DiaryInfoViewModel]]
     var currentTravel: Travel? // 추후 삭제될 코드
     
     init() {
         self.diaryInfos = []
-//        self.idAndTravelDictionary = [:]
         self.travelSections = []
+        self.sectionDiaryDictionary = [:]
     }
     
 }
@@ -32,7 +32,7 @@ extension DiaryListViewModel {
     private func initializeInfo() {
         diaryInfos = []
         travelSections = []
-//        idAndTravelDictionary = [:]
+        sectionDiaryDictionary = [:]
     }
     
     func fetchDiary() {
@@ -59,15 +59,19 @@ extension DiaryListViewModel {
                           let name = travel.name else { return }
                     diaryInfo.travelID = travelID
                     diaryInfo.travelName = name
-//                    idAndTravelDictionary[travelID] = name
                     newDiaries.append(diaryInfo)
-                    
-//                    if idAndTravelDictionary[travelID] == nil {
-//                        idAndTravelDictionary[travelID] = name
-//                    }
                     
                     if !travelSections.contains(name) {
                         travelSections.append(name)
+                    }
+                    
+                    guard let section = travelSections.firstIndex(of: name) else { return }
+                    
+                    if sectionDiaryDictionary[section] == nil {
+                        sectionDiaryDictionary[section] = []
+                        sectionDiaryDictionary[section]?.append(diaryInfo)
+                    } else {
+                        sectionDiaryDictionary[section]?.append(diaryInfo)
                     }
                     
                 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -66,14 +66,7 @@ extension DiaryListViewModel {
                     }
                     
                     guard let section = travelSections.firstIndex(of: name) else { return }
-                    
-                    if sectionDiaryDictionary[section] == nil {
-                        sectionDiaryDictionary[section] = []
-                        sectionDiaryDictionary[section]?.append(diaryInfo)
-                    } else {
-                        sectionDiaryDictionary[section]?.append(diaryInfo)
-                    }
-                    
+                    sectionDiaryDictionary[section, default: []].append(diaryInfo)
                 }
                 // TODO: - 추후삭제
                 if currentTravel == nil {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -10,17 +10,19 @@ import Foundation
 final class DiaryListViewModel: DiaryListViewModelProtocol {
     
     var delegate: DiaryListViewModelDelegate?
+    var travelSections: [String]
     var diaryInfos: [DiaryInfoViewModel] { // 여행UUID: 다이어리 목록
         didSet {
             delegate?.diaryInfoDidChage()
         }
     }
-    var idAndTravelDictionary: [UUID: String]
+//    var idAndTravelDictionary: [UUID: String]
     var currentTravel: Travel? // 추후 삭제될 코드
     
     init() {
         self.diaryInfos = []
-        self.idAndTravelDictionary = [:]
+//        self.idAndTravelDictionary = [:]
+        self.travelSections = []
     }
     
 }
@@ -29,7 +31,8 @@ extension DiaryListViewModel {
     
     private func initializeInfo() {
         diaryInfos = []
-        idAndTravelDictionary = [:]
+        travelSections = []
+//        idAndTravelDictionary = [:]
     }
     
     func fetchDiary() {
@@ -56,8 +59,16 @@ extension DiaryListViewModel {
                           let name = travel.name else { return }
                     diaryInfo.travelID = travelID
                     diaryInfo.travelName = name
-                    idAndTravelDictionary[travelID] = name
+//                    idAndTravelDictionary[travelID] = name
                     newDiaries.append(diaryInfo)
+                    
+//                    if idAndTravelDictionary[travelID] == nil {
+//                        idAndTravelDictionary[travelID] = name
+//                    }
+                    
+                    if !travelSections.contains(name) {
+                        travelSections.append(name)
+                    }
                     
                 }
                 // TODO: - 추후삭제


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 같은 섹션의 내용도 다른 헤더로 분리되는 버그를 수정하였습니다.
- 다이어리를 추가한 후 목록으로 돌아왔을 때 다이어리가 추가되어 있지 않은 버그를 수정하였습니다.
- 다이어리 셀의 이미지가 영역을 넘어서 돌출되는 버그를 수정하였습니다.
- 셀 터치시 첫번째 섹션의 셀로 인식하는 버그를 수정하였습니다.

## 리뷰노트
> 고민, 과정, 궁금한점

> 같은 섹션의 내용도 다른 헤더로 분리되는 버그
- 섹션의 영역을 indexPath.section이 아닌 셀의 indexPath.row로 구분하여 발생한 버그였습니다.

> 다이어리를 추가한 후 목록으로 돌아왔을 때 다이어리가 추가되어 있지 않은 버그
- 다이어리 목록을 패치해오는 과정을 `viewDidLoad`에서 수행하였기 때문에 앱을 실행하면서 단 한번만 패치해오기에 발생한 버그였습니다. 패치 해오는 코드를 `viewWillAppear`로 옮겨 다이어리 목록화면이 나타날때마다 패치하여 해결하였습니다.

> 다이어리 셀의 이미지가 영역을 넘어서 돌출되는 버그
- 다이어리 셀의 `imageView`의 `layer.clipsToBounds`를 `true`로 설정해 이미지 뷰의 `bound`를 넘어가는 컨텐츠는 가리도록 설정하여 해결하였습니다.

> 셀 터치시 첫번째 섹션의 셀로 인식하는 버그
- 세번째 섹션의 첫번째 셀을 누르면, 첫번째 섹션의 첫번째 셀에 대한 다이어리 디테일 화면으로 넘어가는 등, 첫번째 섹션의 셀로만 이동하는 버그가 있었습니다.
- 셀을 섹션으로 구분하지 않고 indexPath.row로만 데이터를 구분해서 발생한 에러였습니다.
- `DiaryListViewModel`에 `sectionDiaryDiction`라는 `[Int: [DiaryInfoViewModel]]` 사전을 만들어 섹션과, 어떤 섹션에 어떤 정보가 있는지를 담고, 섹션의 번호(`indexPath.section`)과 섹션에서의 셀(`indexPath.row`)로 접근하여 수정하였습니다.
- DiaryListViewModel에 데이터를 받아올때마다, 이미 존재하는 섹션번호인지를 검사합니다.
   - 존재하지 않았던 섹션이라면 빈배열을 만들고 데이터를 배열의 첫 원소로 삽입해줍니다.
   - 이미 존재하는 섹션이라면 매열의 원소로 데이터를 삽입해줍니다.
   ```swift
   if sectionDiaryDictionary[section] == nil {
        sectionDiaryDictionary[section] = []
        sectionDiaryDictionary[section]?.append(diaryInfo)
    } else {
        sectionDiaryDictionary[section]?.append(diaryInfo)
    }
   ```

## 스크린샷
<p>
<img width="250" src="https://user-images.githubusercontent.com/76734067/204750371-9a84c451-5166-4753-b6a7-fbc4b863ae3d.png">
<img width="250" src="https://user-images.githubusercontent.com/76734067/204750857-08b47b72-731a-4e6b-861e-514202011fc4.gif">
</p>

