### PR TITLE
[얼굴 인식] 탐지 데이터 뷰컨트롤러 전송, 얼굴 선택 인터렉션

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		BBE695DA29228C570015FAD4 /* TravelListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE695D929228C570015FAD4 /* TravelListViewModelProtocol.swift */; };
 		BBEC31F729349FDE0064CCFA /* FaceDetectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC31F629349FDE0064CCFA /* FaceDetectController.swift */; };
 		BBEC31FA2934B40B0064CCFA /* CGImagePropertyOrientation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC31F92934B40B0064CCFA /* CGImagePropertyOrientation+.swift */; };
+		BBEEFA8A29376BC8005DEF38 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEEFA8929376BC8005DEF38 /* UIImage+.swift */; };
 		BBFAC087291CBDD700D7FD57 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC086291CBDD700D7FD57 /* AppDelegate.swift */; };
 		BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC088291CBDD700D7FD57 /* SceneDelegate.swift */; };
 		BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC08A291CBDD700D7FD57 /* MainTabBarController.swift */; };
@@ -284,6 +285,7 @@
 		BBE695D929228C570015FAD4 /* TravelListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelListViewModelProtocol.swift; sourceTree = "<group>"; };
 		BBEC31F629349FDE0064CCFA /* FaceDetectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceDetectController.swift; sourceTree = "<group>"; };
 		BBEC31F92934B40B0064CCFA /* CGImagePropertyOrientation+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGImagePropertyOrientation+.swift"; sourceTree = "<group>"; };
+		BBEEFA8929376BC8005DEF38 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		BBFAC083291CBDD700D7FD57 /* Doesaegim.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Doesaegim.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBFAC086291CBDD700D7FD57 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBFAC088291CBDD700D7FD57 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -871,6 +873,7 @@
 		BBD0D064291DED61007D0D82 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				BBEEFA8829376BC3005DEF38 /* UIImage */,
 				BBEC31F82934B3ED0064CCFA /* CGImagePropertyOrientation */,
 				EEBA25F9292D1AB2001F8B66 /* String */,
 				BB5DE44A292B8DF4001DA6F6 /* Int */,
@@ -905,6 +908,14 @@
 				BBEC31F92934B40B0064CCFA /* CGImagePropertyOrientation+.swift */,
 			);
 			path = CGImagePropertyOrientation;
+			sourceTree = "<group>";
+		};
+		BBEEFA8829376BC3005DEF38 /* UIImage */ = {
+			isa = PBXGroup;
+			children = (
+				BBEEFA8929376BC8005DEF38 /* UIImage+.swift */,
+			);
+			path = UIImage;
 			sourceTree = "<group>";
 		};
 		BBF10A8929231DAD00F8E078 /* TravelList */ = {
@@ -1375,6 +1386,7 @@
 				BB3DB922292CA79500C70D62 /* DiaryMapInfoViewModel.swift in Sources */,
 				BB3DB926292CF89400C70D62 /* DiaryAnnotation.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
+				BBEEFA8A29376BC8005DEF38 /* UIImage+.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
 				A4EB25C2292BB518002D129A /* DiaryAddLocalRepository.swift in Sources */,
 				B5C096C629238A0B007426B1 /* SearchingLocationViewModelDelegate.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		BBEC31F729349FDE0064CCFA /* FaceDetectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC31F629349FDE0064CCFA /* FaceDetectController.swift */; };
 		BBEC31FA2934B40B0064CCFA /* CGImagePropertyOrientation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEC31F92934B40B0064CCFA /* CGImagePropertyOrientation+.swift */; };
 		BBEEFA8A29376BC8005DEF38 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEEFA8929376BC8005DEF38 /* UIImage+.swift */; };
+		BBEEFA8C29377572005DEF38 /* TempMosaicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEEFA8B29377572005DEF38 /* TempMosaicViewController.swift */; };
 		BBFAC087291CBDD700D7FD57 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC086291CBDD700D7FD57 /* AppDelegate.swift */; };
 		BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC088291CBDD700D7FD57 /* SceneDelegate.swift */; };
 		BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFAC08A291CBDD700D7FD57 /* MainTabBarController.swift */; };
@@ -286,6 +287,7 @@
 		BBEC31F629349FDE0064CCFA /* FaceDetectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaceDetectController.swift; sourceTree = "<group>"; };
 		BBEC31F92934B40B0064CCFA /* CGImagePropertyOrientation+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGImagePropertyOrientation+.swift"; sourceTree = "<group>"; };
 		BBEEFA8929376BC8005DEF38 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		BBEEFA8B29377572005DEF38 /* TempMosaicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempMosaicViewController.swift; sourceTree = "<group>"; };
 		BBFAC083291CBDD700D7FD57 /* Doesaegim.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Doesaegim.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BBFAC086291CBDD700D7FD57 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BBFAC088291CBDD700D7FD57 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				BB6BE55C29360A2F00857D25 /* DetectedFaceCell.swift */,
 				BBEC31F629349FDE0064CCFA /* FaceDetectController.swift */,
 				BB6BE55A2936020300857D25 /* FaceDetectController+CollectionView.swift */,
+				BBEEFA8B29377572005DEF38 /* TempMosaicViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1340,6 +1343,7 @@
 				B5C096B629235416007426B1 /* SearchingLocationViewController.swift in Sources */,
 				BBD0D05B291DE956007D0D82 /* TravelListViewController.swift in Sources */,
 				BBE695D829228B560015FAD4 /* TravelListViewModel.swift in Sources */,
+				BBEEFA8C29377572005DEF38 /* TempMosaicViewController.swift in Sources */,
 				BB9DB80E2928CA6A00102EC8 /* ExpenseListViewModelProtocol.swift in Sources */,
 				B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */,
 				EEB6C4F8292CA8DB0060A459 /* ExpenseAddViewModel.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/DetectedFaceCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/DetectedFaceCell.swift
@@ -93,10 +93,14 @@ extension DetectedFaceCell {
         }
     }
     
+    /// 탐지된 정보를 보고 셀의 이미지를 설정해주는 메서드이다.
+    /// - Parameter info: 탐지 정보를 담은 `DetectInfoViewModel`인스턴스
     func configureInfo(with info: DetectInfoViewModel) {
         imageView.image = info.image
     }
     
+    /// 선택된 셀의 상태정보를 보고 셀의 불투명 뷰, 테두리, 체크마크 이미지 표시여부를 결정해주는 메서드이다.
+    /// - Parameter status: 선택된 셀의 현재 선택상태 `Bool`변수
     func setupCellStatus(with status: Bool) {
         switch status {
         case true:

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/DetectedFaceCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/DetectedFaceCell.swift
@@ -20,6 +20,24 @@ final class DetectedFaceCell: UICollectionViewCell {
         return imageView
     }()
     
+    let opacityView: UIView = {
+        let view = UIView()
+        
+        view.backgroundColor = .grey4
+        view.layer.opacity = 0.35
+        
+        return view
+    }()
+    
+    let checkmarkImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        imageView.image = UIImage(systemName: "checkmark.circle.fill")
+        imageView.tintColor = .primaryOrange
+        
+        return imageView
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -34,14 +52,27 @@ final class DetectedFaceCell: UICollectionViewCell {
 extension DetectedFaceCell {
     
     private func configure() {
+        
+        configureSubviews()
+        configureView()
+        configureConstraints()
+    }
+    
+    private func configureView() {
         layer.cornerRadius = 10
         layer.masksToBounds = true
-        configureSubviews()
-        configureConstraints()
+        layer.borderColor = UIColor.primaryOrange?.cgColor
+        layer.borderWidth = 0
+        
+        opacityView.isHidden = true
+        checkmarkImageView.isHidden = true
+        
     }
     
     private func configureSubviews() {
         addSubview(imageView)
+        addSubview(opacityView)
+        addSubview(checkmarkImageView)
     }
     
     private func configureConstraints() {
@@ -49,9 +80,33 @@ extension DetectedFaceCell {
             $0.horizontalEdges.equalToSuperview()
             $0.verticalEdges.equalToSuperview()
         }
+        
+        opacityView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.verticalEdges.equalToSuperview()
+        }
+        
+        checkmarkImageView.snp.makeConstraints {
+            $0.width.height.equalTo(22)
+            $0.top.equalToSuperview().offset(8)
+            $0.trailing.equalToSuperview().offset(-8)
+        }
     }
     
     func configureInfo(with info: DetectInfoViewModel) {
         imageView.image = info.image
+    }
+    
+    func setupCellStatus(with status: Bool) {
+        switch status {
+        case true:
+            opacityView.isHidden = false
+            checkmarkImageView.isHidden = false
+            layer.borderWidth = 5
+        case false:
+            opacityView.isHidden = true
+            checkmarkImageView.isHidden = true
+            layer.borderWidth = 0
+        }
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController+CollectionView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController+CollectionView.swift
@@ -20,6 +20,7 @@ extension FaceDetectController {
         
         let detectedCell = CellRegistration { cell, _, identifier in
             cell.configureInfo(with: identifier)
+            cell.setupCellStatus(with: identifier.isSelected)
         }
         
         detectDataSource = DataSource(
@@ -59,4 +60,21 @@ extension FaceDetectController {
         return layout
     }
     
+}
+
+extension FaceDetectController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {1
+        // 1. viewModel의 detectInfo -> indexPath.row 번째 모델을 조회
+        // 2. isSelected프로퍼티를 셀의 메서드에 전달한다.
+        // 3. 메서드에서 알아서 결정
+        
+        guard let viewModel = viewModel,
+              indexPath.row < viewModel.detectInfos.count,
+              let cell = collectionView.cellForItem(at: indexPath) as? DetectedFaceCell else { return }
+        
+        let isSelected = viewModel.detectInfos[indexPath.row].isSelected
+        viewModel.detectInfos[indexPath.row].isSelected.toggle() // 값을 뒤집어준다.
+        cell.setupCellStatus(with: isSelected)
+        
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController+CollectionView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController+CollectionView.swift
@@ -63,7 +63,7 @@ extension FaceDetectController {
 }
 
 extension FaceDetectController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {1
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // 1. viewModel의 detectInfo -> indexPath.row 번째 모델을 조회
         // 2. isSelected프로퍼티를 셀의 메서드에 전달한다.
         // 3. 메서드에서 알아서 결정

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -108,7 +108,7 @@ final class FaceDetectController: UIViewController {
         configureCollectionViewDataSource()
     }
     
-    override func viewDidLayoutSubviews() {
+    override func viewDidAppear(_ animated: Bool) {
         startDetect()
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -294,8 +294,6 @@ extension FaceDetectController: FaceDetectViewModeleDelegate {
         faces.forEach { observation in
             let faceBox = boundingBox(forRegionOfInterest: observation.boundingBox, withInImageBounds: bounds)
             let faceLayer = shapeLayer(color: .yellow, frame: faceBox)
-            // TODO: - 얼굴이 9개인데 왜 그 이상으로 호출되지...? 흠...
-    //            viewModel.addDetectInfo(with: self.currentImage, bound: bounds)
             pathLayer?.addSublayer(faceLayer)
             
         }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -39,6 +39,15 @@ final class FaceDetectController: UIViewController {
         return imageView
     }()
     
+    private let guideLabel: UILabel = {
+        let label = UILabel()
+        
+        label.textColor = .primaryOrange
+        label.text = "모자이크 처리할 얼굴을 선택해주세요"
+        
+        return label
+    }()
+    
     lazy var collectionView: UICollectionView = {
         let layout = createCompositionalLayout()
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
@@ -105,6 +114,7 @@ final class FaceDetectController: UIViewController {
         collectionView.delegate = self
         configureSubviews()
         configureConstraints()
+        configureNavigationBar()
         configureButtonAction()
         configureCollectionViewDataSource()
     }
@@ -122,6 +132,7 @@ extension FaceDetectController {
     
     private func configureSubviews() {
         view.addSubview(imageView)
+        view.addSubview(guideLabel)
         view.addSubview(collectionView)
         view.addSubview(confirmButton)
     }
@@ -129,13 +140,18 @@ extension FaceDetectController {
     private func configureConstraints() {
         imageView.snp.makeConstraints {
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(60)
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(8)
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(6)
             $0.height.equalTo(imageView.snp.width)
+        }
+        
+        guideLabel.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.bottom).offset(6)
+            $0.centerX.equalToSuperview()
         }
         
         collectionView.snp.makeConstraints {
             $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
-            $0.top.equalTo(imageView.snp.bottom).offset(6)
+            $0.top.equalTo(guideLabel.snp.bottom).offset(6)
         }
         
         confirmButton.snp.makeConstraints {
@@ -144,6 +160,10 @@ extension FaceDetectController {
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-6)
             $0.height.equalTo(40)
         }
+    }
+    
+    private func configureNavigationBar() {
+        navigationItem.title = "얼굴 선택하기"
     }
     
     private func configureButtonAction() {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -177,7 +177,7 @@ extension FaceDetectController {
         pathLayer = nil
         imageView.image = nil
         
-        let correctedImage = scaleAndOrient(image: image)
+        let correctedImage = image.scaleAndOrient()
         
         imageView.image = correctedImage
         
@@ -211,86 +211,6 @@ extension FaceDetectController {
         pathLayer = drawingLayer
         viewModel?.pathLayer = pathLayer
         view.layer.addSublayer(pathLayer!)
-    }
-    
-    /// 이미지의 해상도를 재조정하고 상태에 따라 방향전환을 해주는 메서드
-    /// - Parameter image: 반영할 `UIImage`
-    /// - Returns: 해상도와 방향이 조정된 `UIImage`
-    private func scaleAndOrient(image: UIImage) -> UIImage {
-        
-        let maxResolution: CGFloat = 640
-        
-        guard let cgImage = image.cgImage else { return image }
-        
-        let width = CGFloat(cgImage.width)
-        let height = CGFloat(cgImage.height)
-        var transform = CGAffineTransform.identity
-        
-        var bounds = CGRect(x: 0, y: 0, width: width, height: height)
-        
-        let isWidthBiggerThanMaxResolution = width > maxResolution
-        let isHeightBiggerThanMaxResolution = height > maxResolution
-        if isWidthBiggerThanMaxResolution || isHeightBiggerThanMaxResolution {
-            let ratio = width / height
-            if width > height {
-                bounds.size.width = maxResolution
-                bounds.size.height = round(maxResolution / ratio)
-            } else {
-                bounds.size.width = round(maxResolution * ratio)
-                bounds.size.height = maxResolution
-            }
-        }
-        
-        let scaleRatio = bounds.size.width / width
-        let orientation = image.imageOrientation
-        switch orientation {
-        case .up:
-            transform = .identity
-        case .down:
-            transform = CGAffineTransform(translationX: width, y: height).rotated(by: .pi)
-        case .left:
-            let boundsHeight = bounds.size.height
-            bounds.size.height = bounds.size.width
-            bounds.size.width = boundsHeight
-            transform = CGAffineTransform(translationX: 0, y: width).rotated(by: 3.0 * .pi / 2.0)
-        case .right:
-            let boundsHeight = bounds.size.height
-            bounds.size.height = bounds.size.width
-            bounds.size.width = boundsHeight
-            transform = CGAffineTransform(translationX: height, y: 0).rotated(by: .pi / 2.0)
-        case .upMirrored:
-            transform = CGAffineTransform(translationX: width, y: 0).scaledBy(x: -1, y: 1)
-        case .downMirrored:
-            transform = CGAffineTransform(translationX: 0, y: height).scaledBy(x: 1, y: -1)
-        case .leftMirrored:
-            let boundsHeight = bounds.size.height
-            bounds.size.height = bounds.size.width
-            bounds.size.width = boundsHeight
-            transform = CGAffineTransform(translationX: height, y: width).scaledBy(x: -1, y: 1).rotated(by: 3.0 * .pi / 2.0)
-        case .rightMirrored:
-            let boundsHeight = bounds.size.height
-            bounds.size.height = bounds.size.width
-            bounds.size.width = boundsHeight
-            transform = CGAffineTransform(scaleX: -1, y: 1).rotated(by: .pi / 2.0)
-        default:
-            transform = .identity
-        }
-        
-        return UIGraphicsImageRenderer(size: bounds.size).image { rendererContext in
-            let context = rendererContext.cgContext
-            
-            if orientation == .right || orientation == .left {
-                context.scaleBy(x: -scaleRatio, y: scaleRatio)
-                context.translateBy(x: -height, y: 0)
-            } else {
-                context.scaleBy(x: scaleRatio, y: -scaleRatio)
-                context.translateBy(x: 0, y: -height)
-            }
-            
-            context.concatenate(transform)
-            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-        }
-        
     }
     
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -101,7 +101,8 @@ final class FaceDetectController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        collectionView.delegate = self
         configureSubviews()
         configureConstraints()
         configureButtonAction()
@@ -153,6 +154,11 @@ extension FaceDetectController {
     
     @objc private func confirmButtonDidTap() {
         print("버튼이 탭 되었습니다~")
+        guard let viewModel = viewModel else { return }
+        viewModel.detectInfos.forEach { infoViewModel in
+            let bound = infoViewModel.bound
+            print(bound)
+        }
     }
     
     // MARK: - ETC

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/FaceDetectController.swift
@@ -153,12 +153,15 @@ extension FaceDetectController {
     // MARK: - Button Action
     
     @objc private func confirmButtonDidTap() {
-        print("버튼이 탭 되었습니다~")
-        guard let viewModel = viewModel else { return }
-        viewModel.detectInfos.forEach { infoViewModel in
-            let bound = infoViewModel.bound
-            print(bound)
-        }
+        guard let viewModel = viewModel,
+              let image = currentImage else { return }
+        let selectedFaces = viewModel.detectInfos.filter({ $0.isSelected })
+        
+        // 다음 뷰 컨트롤러에 현재 작업하고 있는 이미지와 선택된 얼굴의 DetectInfoViewModel인스턴스 배열을 넘겨준다.
+        // 모자이크 처리 할 뷰 컨트롤러에 이미지와 [DetectInfoViewModel] 파라미터를 받도록 해주세요
+        let mosaicController = TempMosaicViewController(image: image, selectedFaces: selectedFaces)
+        navigationController?.pushViewController(mosaicController, animated: true)
+        
     }
     
     // MARK: - ETC

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/TempMosaicViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/TempMosaicViewController.swift
@@ -1,0 +1,31 @@
+//
+//  TempMosaicViewController.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/30.
+//
+
+import UIKit
+
+class TempMosaicViewController: UIViewController {
+
+    private var image: UIImage?
+    private var selectedFaces: [DetectInfoViewModel]?
+    
+    init(image: UIImage, selectedFaces: [DetectInfoViewModel]) {
+        super.init(nibName: nil, bundle: nil)
+        self.image = image
+        self.selectedFaces = selectedFaces
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        navigationItem.title = "임시 모자이크 뷰"
+    }
+
+}

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/TempMosaicViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/TempMosaicViewController.swift
@@ -7,7 +7,8 @@
 
 import UIKit
 
-class TempMosaicViewController: UIViewController {
+/// 임시 모자이크 뷰컨트롤러 입니다.
+final class TempMosaicViewController: UIViewController {
 
     private var image: UIImage?
     private var selectedFaces: [DetectInfoViewModel]?

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+.swift
@@ -1,0 +1,92 @@
+//
+//  UIImage+.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/11/30.
+//
+
+import UIKit
+
+
+extension UIImage {
+    /// 이미지의 해상도를 재조정하고 상태에 따라 방향전환을 해주는 메서드
+    /// - Parameter image: 반영할 `UIImage`
+    /// - Returns: 해상도와 방향이 조정된 `UIImage`
+    public func scaleAndOrient() -> UIImage {
+        
+        let maxResolution: CGFloat = 640
+        
+        guard let cgImage = self.cgImage else { return self }
+        
+        let width = CGFloat(cgImage.width)
+        let height = CGFloat(cgImage.height)
+        var transform = CGAffineTransform.identity
+        
+        var bounds = CGRect(x: 0, y: 0, width: width, height: height)
+        
+        let isWidthBiggerThanMaxResolution = width > maxResolution
+        let isHeightBiggerThanMaxResolution = height > maxResolution
+        if isWidthBiggerThanMaxResolution || isHeightBiggerThanMaxResolution {
+            let ratio = width / height
+            if width > height {
+                bounds.size.width = maxResolution
+                bounds.size.height = round(maxResolution / ratio)
+            } else {
+                bounds.size.width = round(maxResolution * ratio)
+                bounds.size.height = maxResolution
+            }
+        }
+        
+        let scaleRatio = bounds.size.width / width
+        let orientation = self.imageOrientation
+        switch orientation {
+        case .up:
+            transform = .identity
+        case .down:
+            transform = CGAffineTransform(translationX: width, y: height).rotated(by: .pi)
+        case .left:
+            let boundsHeight = bounds.size.height
+            bounds.size.height = bounds.size.width
+            bounds.size.width = boundsHeight
+            transform = CGAffineTransform(translationX: 0, y: width).rotated(by: 3.0 * .pi / 2.0)
+        case .right:
+            let boundsHeight = bounds.size.height
+            bounds.size.height = bounds.size.width
+            bounds.size.width = boundsHeight
+            transform = CGAffineTransform(translationX: height, y: 0).rotated(by: .pi / 2.0)
+        case .upMirrored:
+            transform = CGAffineTransform(translationX: width, y: 0).scaledBy(x: -1, y: 1)
+        case .downMirrored:
+            transform = CGAffineTransform(translationX: 0, y: height).scaledBy(x: 1, y: -1)
+        case .leftMirrored:
+            let boundsHeight = bounds.size.height
+            bounds.size.height = bounds.size.width
+            bounds.size.width = boundsHeight
+            transform = CGAffineTransform(translationX: height, y: width).scaledBy(x: -1, y: 1).rotated(by: 3.0 * .pi / 2.0)
+        case .rightMirrored:
+            let boundsHeight = bounds.size.height
+            bounds.size.height = bounds.size.width
+            bounds.size.width = boundsHeight
+            transform = CGAffineTransform(scaleX: -1, y: 1).rotated(by: .pi / 2.0)
+        default:
+            transform = .identity
+        }
+        
+        return UIGraphicsImageRenderer(size: bounds.size).image { rendererContext in
+            let context = rendererContext.cgContext
+            
+            if orientation == .right || orientation == .left {
+                context.scaleBy(x: -scaleRatio, y: scaleRatio)
+                context.translateBy(x: -height, y: 0)
+            } else {
+                context.scaleBy(x: scaleRatio, y: -scaleRatio)
+                context.translateBy(x: 0, y: -height)
+            }
+            
+            context.concatenate(transform)
+            context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        }
+        
+    }
+}
+

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+.swift
@@ -62,7 +62,9 @@ extension UIImage {
             let boundsHeight = bounds.size.height
             bounds.size.height = bounds.size.width
             bounds.size.width = boundsHeight
-            transform = CGAffineTransform(translationX: height, y: width).scaledBy(x: -1, y: 1).rotated(by: 3.0 * .pi / 2.0)
+            transform = CGAffineTransform(
+                translationX: height, y: width
+            ).scaledBy(x: -1, y: 1).rotated(by: 3.0 * .pi / 2.0)
         case .rightMirrored:
             let boundsHeight = bounds.size.height
             bounds.size.height = bounds.size.width
@@ -89,4 +91,5 @@ extension UIImage {
         
     }
 }
+
 


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- `scaleAndOrient` 메서드를 `UIImage`익스텐션으로 구현하였습니다.
- 얼굴인식 작업이 여러번 수행되는 버그를 수정하였습니다.
- 셀 선택 액션을 추가하였습니다. 사용자가 선택했다는 것을 알 수 있게끔 구현하였습니다.
- 임시 모자이크 뷰컨트롤러로 데이터를 전송하였습니다.
- 얼굴인식 뷰에 레이블, 네비게이션 타이틀 등 UI요소를 추가하였습니다.

## 리뷰노트
> 고민, 과정, 궁금한점

### 얼굴인식 작업이 여러번 수행되는 버그를 수정
- 얼굴인식 작업이 여러번 수행되었던 이유는, 얼굴 인식 작업의 시작을 `viewDidLayoutSubviews`메서드에서 수행하였기 때문이였습니다.
   - `viewDidLayoutSubviews`는 화면의 frame상에 변화가 있을 때, frame을 지정하기 위해서 호출되는 메서드입니다.
   - 한번 얼굴 인식 작업이 완료 -> 컬렉션뷰의 DiffableDataSource가 변화를 탐지 -> `UICollectionView`의 셀을 재구성 -> Frame이 변하므로 `viewDidLayoutSubviews` 재호출... -> 어디선가 연쇄가 끊길 때까지 호출
   - 이와같은 문제점이 있어 여러번 수행되었습니다.
   - frame도 결정되고, 라이프 사이클에서 뷰가 나타날때마다 한번만 호출되는 `viewDidAppear`메서드 안에 구현하여 버그를 해결하였습니다.
---
### 컬렉션뷰의 셀을 선택했을 때 테두리를 생성
- 탐지된 정보를 가지고 있는 `DetectInfoViewModel`에는 `isSelected`라는 선택여부를 가지는 `Bool` 변수가 위치합니다.
- `UICollectionViewDelegate`를 채택하여, 셀을 선택할 때마다 해당 셀에 접근해 isSelected를 전달하고 현재상태에서 토글시켜주었습니다.
- 셀의 메서드가 `isSelected`의 정보를 받아 셀에 표시될 내용을 결정합니다.
---
### 임시 모자이크 뷰에 데이터 전달
- 모자이크를 함에 있어 필요한 정보는 다음 두가지 라고 생각했습니다.
   - 현재 작업하고 있는 이미지(`UIImage`)
   - 얼굴인식한 정보가 담겨있는 `DetectInfoViewModel` 배열
- `DetectInfoViewModel` 배열에는 당연히 선택한 얼굴에 대한 정보만 전달하게 됩니다. 실제로 필요한 이미지는 뷰모델 안에 있는 `bound(CGRect)`뿐이라 이것만 전달할까 생각하였으나 혹시나 추가적으로 필요한정보가 있을 수도있다 라고 생각하여 일단 전부 전달하였습니다. 필요없다면 나중에 바꾸는것은 간단하게 가능합니다.
- `DetectInfoViewModel`의 `bound` 프로퍼티는 얼굴인식을 해서 얻을 수 있는 `boundingBox`의 비율 데이터, 왼쪽 아래 기준의 프레임이 아닌, 일반적으로 사용하는 절대값, 왼쪽 위를 (0,0)으로 하는 `bound`로 정제하여 삽입하였습니다. 모자이크 하실때는 그냥 사용하시면 됩니다.

## 스크린샷

<img width="300" src="https://user-images.githubusercontent.com/76734067/204793317-900a5dd3-a16f-485c-b9b7-4ecbe38d473c.gif">