### PR TITLE
[커스텀 그래프] 막대 그래프 및 애니메이션 구현

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B595A984292CE53100C3B897 /* ExpenseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595A983292CE53100C3B897 /* ExpenseType.swift */; };
 		B5B497CB29374BEF009AE4AC /* CustomBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */; };
 		B5B497CD29374C58009AE4AC /* BarShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */; };
+		B5B497D6293777EE009AE4AC /* ExpenseChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497D5293777EE009AE4AC /* ExpenseChartView.swift */; };
 		B5C096B629235416007426B1 /* SearchingLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B529235416007426B1 /* SearchingLocationViewController.swift */; };
 		B5C096B829235428007426B1 /* SearchingLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B729235428007426B1 /* SearchingLocationView.swift */; };
 		B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096BB29235B08007426B1 /* SearchResultCell.swift */; };
@@ -227,6 +228,7 @@
 		B595A983292CE53100C3B897 /* ExpenseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseType.swift; sourceTree = "<group>"; };
 		B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBarChart.swift; sourceTree = "<group>"; };
 		B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarShapeLayer.swift; sourceTree = "<group>"; };
+		B5B497D5293777EE009AE4AC /* ExpenseChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseChartView.swift; sourceTree = "<group>"; };
 		B5C096B529235416007426B1 /* SearchingLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewController.swift; sourceTree = "<group>"; };
 		B5C096B729235428007426B1 /* SearchingLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationView.swift; sourceTree = "<group>"; };
 		B5C096BB29235B08007426B1 /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 				BBB31A3D2926007D00C9E3A9 /* ExpenseListViewController.swift */,
 				BB7D9A252926088A00BF2BD6 /* ExpensePlaceholdView.swift */,
 				BB7D9A2929261C0600BF2BD6 /* ExpenseListCell.swift */,
+				B5B497D5293777EE009AE4AC /* ExpenseChartView.swift */,
 				BBDB2E9329262BB300752924 /* ExpenseCollectionHeaderView.swift */,
 				BBDB2E95292635FD00752924 /* ExpenseSectionHeaderView.swift */,
 			);
@@ -1391,6 +1394,7 @@
 				BB9DB8122928D0BA00102EC8 /* PersistentRepositoryProtocol.swift in Sources */,
 				A4CC04C62922799600BB678B /* CheckBox.swift in Sources */,
 				BB3DB922292CA79500C70D62 /* DiaryMapInfoViewModel.swift in Sources */,
+				B5B497D6293777EE009AE4AC /* ExpenseChartView.swift in Sources */,
 				BB3DB926292CF89400C70D62 /* DiaryAnnotation.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		B57D962E2922318F00B510B8 /* ExpenseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962D2922318F00B510B8 /* ExpenseDTO.swift */; };
 		B57D9630292231FC00B510B8 /* DiaryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962F292231FC00B510B8 /* DiaryDTO.swift */; };
 		B595A984292CE53100C3B897 /* ExpenseType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B595A983292CE53100C3B897 /* ExpenseType.swift */; };
+		B5B497CB29374BEF009AE4AC /* CustomBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */; };
+		B5B497CD29374C58009AE4AC /* BarShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */; };
 		B5C096B629235416007426B1 /* SearchingLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B529235416007426B1 /* SearchingLocationViewController.swift */; };
 		B5C096B829235428007426B1 /* SearchingLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B729235428007426B1 /* SearchingLocationView.swift */; };
 		B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096BB29235B08007426B1 /* SearchResultCell.swift */; };
@@ -223,6 +225,8 @@
 		B57D962D2922318F00B510B8 /* ExpenseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseDTO.swift; sourceTree = "<group>"; };
 		B57D962F292231FC00B510B8 /* DiaryDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryDTO.swift; sourceTree = "<group>"; };
 		B595A983292CE53100C3B897 /* ExpenseType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseType.swift; sourceTree = "<group>"; };
+		B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBarChart.swift; sourceTree = "<group>"; };
+		B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarShapeLayer.swift; sourceTree = "<group>"; };
 		B5C096B529235416007426B1 /* SearchingLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewController.swift; sourceTree = "<group>"; };
 		B5C096B729235428007426B1 /* SearchingLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationView.swift; sourceTree = "<group>"; };
 		B5C096BB29235B08007426B1 /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
@@ -526,6 +530,7 @@
 			children = (
 				B53763D4292B61A40073BF46 /* CustomChartItem.swift */,
 				B53763E4292B99D10073BF46 /* PieChart */,
+				B5B497C929374BDC009AE4AC /* BarChart */,
 			);
 			path = CustomGraph;
 			sourceTree = "<group>";
@@ -568,6 +573,15 @@
 				B57D962F292231FC00B510B8 /* DiaryDTO.swift */,
 			);
 			path = PersistentDTO;
+			sourceTree = "<group>";
+		};
+		B5B497C929374BDC009AE4AC /* BarChart */ = {
+			isa = PBXGroup;
+			children = (
+				B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */,
+				B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */,
+			);
+			path = BarChart;
 			sourceTree = "<group>";
 		};
 		B5C096B2292353EE007426B1 /* SearchingLocation */ = {
@@ -1341,6 +1355,7 @@
 				EEB6C503292CC88B0060A459 /* ExchangeResponse.swift in Sources */,
 				A4CC04A429221EEE00BB678B /* Plan+CoreDataClass.swift in Sources */,
 				EEB6C500292CC4910060A459 /* Resource.swift in Sources */,
+				B5B497CB29374BEF009AE4AC /* CustomBarChart.swift in Sources */,
 				EE116C5E2924CB6B0017B519 /* TravelAddViewProtocol.swift in Sources */,
 				EEB6C4FB292CA9200060A459 /* ExpenseAddViewProtocol.swift in Sources */,
 				BBDB2E96292635FD00752924 /* ExpenseSectionHeaderView.swift in Sources */,
@@ -1399,6 +1414,7 @@
 				B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */,
 				B5DE4D4029271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift in Sources */,
 				BBE695DA29228C570015FAD4 /* TravelListViewModelProtocol.swift in Sources */,
+				B5B497CD29374C58009AE4AC /* BarShapeLayer.swift in Sources */,
 				B5C096C029236BC0007426B1 /* SearchResultCellViewModel.swift in Sources */,
 				A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */,
 				BB6BE55B2936020300857D25 /* FaceDetectController+CollectionView.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		B5B497CB29374BEF009AE4AC /* CustomBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */; };
 		B5B497CD29374C58009AE4AC /* BarShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */; };
 		B5B497D6293777EE009AE4AC /* ExpenseChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497D5293777EE009AE4AC /* ExpenseChartView.swift */; };
+		B5B497DA29378ABF009AE4AC /* BarBackgroundLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497D929378ABF009AE4AC /* BarBackgroundLayer.swift */; };
+		B5B497DC29379FC3009AE4AC /* BarTextLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B497DB29379FC3009AE4AC /* BarTextLayer.swift */; };
 		B5C096B629235416007426B1 /* SearchingLocationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B529235416007426B1 /* SearchingLocationViewController.swift */; };
 		B5C096B829235428007426B1 /* SearchingLocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096B729235428007426B1 /* SearchingLocationView.swift */; };
 		B5C096BC29235B08007426B1 /* SearchResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C096BB29235B08007426B1 /* SearchResultCell.swift */; };
@@ -229,6 +231,8 @@
 		B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBarChart.swift; sourceTree = "<group>"; };
 		B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarShapeLayer.swift; sourceTree = "<group>"; };
 		B5B497D5293777EE009AE4AC /* ExpenseChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseChartView.swift; sourceTree = "<group>"; };
+		B5B497D929378ABF009AE4AC /* BarBackgroundLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarBackgroundLayer.swift; sourceTree = "<group>"; };
+		B5B497DB29379FC3009AE4AC /* BarTextLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarTextLayer.swift; sourceTree = "<group>"; };
 		B5C096B529235416007426B1 /* SearchingLocationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewController.swift; sourceTree = "<group>"; };
 		B5C096B729235428007426B1 /* SearchingLocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationView.swift; sourceTree = "<group>"; };
 		B5C096BB29235B08007426B1 /* SearchResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultCell.swift; sourceTree = "<group>"; };
@@ -582,6 +586,8 @@
 			children = (
 				B5B497CA29374BEF009AE4AC /* CustomBarChart.swift */,
 				B5B497CC29374C58009AE4AC /* BarShapeLayer.swift */,
+				B5B497D929378ABF009AE4AC /* BarBackgroundLayer.swift */,
+				B5B497DB29379FC3009AE4AC /* BarTextLayer.swift */,
 			);
 			path = BarChart;
 			sourceTree = "<group>";
@@ -1411,6 +1417,7 @@
 				BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */,
 				BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */,
 				EEBA25FB292D1AE3001F8B66 /* String+ConvertRemoveComma.swift in Sources */,
+				B5B497DA29378ABF009AE4AC /* BarBackgroundLayer.swift in Sources */,
 				EEDB753329260DFB0069A7F5 /* PlanAddViewModel.swift in Sources */,
 				BBD0D05F291DE97F007D0D82 /* MapViewController.swift in Sources */,
 				A4C3BB6F292F05C1001C0514 /* ProgressiveImageView.swift in Sources */,
@@ -1478,6 +1485,7 @@
 				EEDB752F2925E8DD0069A7F5 /* CalendarViewController.swift in Sources */,
 				B5D64E67292DFED500E1CC81 /* DiaryDetailViewController.swift in Sources */,
 				B5D64E6C292E22A400E1CC81 /* DiaryDetailViewModel.swift in Sources */,
+				B5B497DC29379FC3009AE4AC /* BarTextLayer.swift in Sources */,
 				EEB6C4FD292CC29B0060A459 /* NetworkManager.swift in Sources */,
 				A4C3BB75292F3810001C0514 /* ImageStatus.swift in Sources */,
 				EE85FBC6292BAADC00FF0C7C /* ExpenseAddView.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ExpenseChartView: UIView {
+final class ExpenseChartView: UIView {
 
     // MARK: - UI Properties
     
@@ -42,14 +42,14 @@ class ExpenseChartView: UIView {
     // MARK: - Properties
     
     /// 원형 차트 데이터
-    private var pieChartData: [CustomChartItem] = ExpenseChartView.dummyData {
+    private var pieChartData: [CustomChartItem<ExpenseType>] = ExpenseChartView.pieChartDummies {
         didSet {
             pieChart.setupData(with: pieChartData)
         }
     }
     
     /// 막대 차트 데이터
-    private var barChartData: [CustomChartItem] = ExpenseChartView.dummyData {
+    private var barChartData: [CustomChartItem<Date>] = ExpenseChartView.barChartDummies {
         didSet {
             barChart.setupData(with: barChartData)
         }
@@ -136,14 +136,14 @@ class ExpenseChartView: UIView {
     /// - Parameter data: 원본 지출 데이터
     private func setupPieChartData(with data: ExpenseListViewModelProtocol) {
         var chartData: [CustomChartItem] = ExpenseType.allCases.map {
-            CustomChartItem(category: $0, date: Date(), value: 0)
+            CustomChartItem(criterion: $0, value: 0)
         } // 사용자가 지출정보를 추가하는 순서대로 조각이 표시되는 게 아닌, 카테고리 자체 순서대로 조각이 추가되도록
         
         data.expenseInfos.forEach { item in
             guard let type = ExpenseType(rawValue: item.category) else { return }
             let graphValue = CGFloat(item.cost)
             
-            if let foundIndex = chartData.firstIndex(where: { $0.category == type }) {
+            if let foundIndex = chartData.firstIndex(where: { $0.criterion == type }) {
                 chartData[foundIndex].value += graphValue
             }
         }
@@ -156,18 +156,18 @@ class ExpenseChartView: UIView {
     /// - Parameter data: 원본 지출 데이터
     private func setupBarChartData(with data: ExpenseListViewModelProtocol) {
         let expenseData = data.expenseInfos.sorted { $0.date < $1.date }
-        var chartData: [CustomChartItem] = []
+        var chartData: [CustomChartItem<Date>] = []
         
         expenseData.forEach { item in
             let graphValue = CGFloat(item.cost)
             
-            if let foundIndex = chartData.firstIndex(where: {$0.date == item.date }) {
+            if let foundIndex = chartData.firstIndex(where: {$0.criterion == item.date }) {
                 chartData[foundIndex].value += graphValue
             } else {
-                chartData.append(CustomChartItem(date: item.date, value: graphValue))
+                chartData.append(CustomChartItem(criterion: item.date, value: graphValue))
             }
         }
-        chartData.sort { ($0.date ?? Date()) < ($1.date ?? Date()) }
+        chartData.sort { $0.criterion < $1.criterion }
         
         if !chartData.isEmpty { self.barChartData = chartData }
     }
@@ -175,30 +175,33 @@ class ExpenseChartView: UIView {
 }
 
 extension ExpenseChartView {
-    static let dummyData = [
+    static let pieChartDummies: [CustomChartItem<ExpenseType>] = [
+        CustomChartItem(criterion: .food, value: 70),
+        CustomChartItem(criterion: .shopping, value: 30),
+        CustomChartItem(criterion: .transportation, value: 50),
+        CustomChartItem(criterion: .room, value: 60),
+        CustomChartItem(criterion: .other, value: 20)
+    ]
+    
+    static let barChartDummies: [CustomChartItem<Date>] = [
         CustomChartItem(
-            category: .food,
-            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
             value: 70
         ),
         CustomChartItem(
-            category: .shopping,
-            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
             value: 30
         ),
         CustomChartItem(
-            category: .transportation,
-            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
             value: 50
         ),
         CustomChartItem(
-            category: .room,
-            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
             value: 60
         ),
         CustomChartItem(
-            category: .other,
-            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
             value: 20
         )
     ]

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -1,0 +1,205 @@
+//
+//  ExpenseChartView.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/11/30.
+//
+
+import UIKit
+
+class ExpenseChartView: UIView {
+
+    // MARK: - UI Properties
+    
+    private let segmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: ["카테고리별", "날짜별"])
+        control.selectedSegmentIndex = 0
+        
+        return control
+    }()
+    
+    /// 원형 차트 뷰
+    private lazy var pieChart = CustomPieChart(items: pieChartData)
+    
+    /// 막대 차트 뷰
+    private lazy var barChart = CustomBarChart(items: barChartData)
+    
+    /// 원형 차트 또는 막대 차트가 표시되는 뷰
+    private let chartView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    
+    /// 모든 컨텐츠가 포함되는 스택 뷰
+    private let contentStack: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        
+        return stackView
+    }()
+    
+    
+    // MARK: - Properties
+    
+    /// 원형 차트 데이터
+    private var pieChartData: [CustomChartItem] = ExpenseChartView.dummyData {
+        didSet {
+            pieChart.setupData(with: pieChartData)
+        }
+    }
+    
+    /// 막대 차트 데이터
+    private var barChartData: [CustomChartItem] = ExpenseChartView.dummyData {
+        didSet {
+            barChart.setupData(with: barChartData)
+        }
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Configure Functions
+    
+    private func configure() {
+        configureSubviews()
+        configureConstraint()
+        configureInitialChartView()
+        configureSegmentedControl()
+    }
+    
+    private func configureSubviews() {
+        chartView.addSubviews(pieChart, barChart)
+        contentStack.addArrangedSubviews(segmentedControl, chartView)
+        
+        addSubview(contentStack)
+    }
+    
+    private func configureConstraint() {
+        pieChart.snp.makeConstraints { $0.edges.equalToSuperview() }
+        barChart.snp.makeConstraints { $0.edges.equalToSuperview() }
+        
+        contentStack.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+    
+    /// 초기에 화면 진입 시 어떤 차트를 보여줄 것인지 지정한다.
+    private func configureInitialChartView() {
+        pieChart.isHidden = false
+        barChart.isHidden = true
+    }
+    
+    /// 세그먼티드 컨트롤에 액션을 추가한다.
+    private func configureSegmentedControl() {
+        segmentedControl.addTarget(
+            self,
+            action: #selector(segmentedControlValueDidChange),
+            for: .valueChanged
+        )
+    }
+    
+    // MARK: - objc Functions
+    
+    /// 세그먼티드 컨트롤의 값이 변경되었을 때 보여줄 차트를 지정한다.
+    @objc func segmentedControlValueDidChange() {
+        let selectedIndex = segmentedControl.selectedSegmentIndex
+        
+        pieChart.isHidden = selectedIndex == 0 ? false : true
+        barChart.isHidden = !pieChart.isHidden
+        
+        if !pieChart.isHidden {
+            pieChart.executeAnimation()
+        } else {
+            barChart.executeAnimation()
+        }
+    }
+    
+    // MARK: - Setup Functions
+    
+    /// 지출 데이터를 전달 받아 원형 그래프와 막대 그래프용 데이터로 변형 및 지정한다.
+    /// - Parameter data: 지출 데이터
+    /// - Returns: 지출데이터의 존재여부
+    func setupData(with data: ExpenseListViewModelProtocol) {
+        setupPieChartData(with: data)
+        setupBarChartData(with: data)
+    }
+    
+    /// 원형 차트의 데이터를 설정한다.
+    /// - Parameter data: 원본 지출 데이터
+    private func setupPieChartData(with data: ExpenseListViewModelProtocol) {
+        var chartData: [CustomChartItem] = ExpenseType.allCases.map {
+            CustomChartItem(category: $0, date: Date(), value: 0)
+        } // 사용자가 지출정보를 추가하는 순서대로 조각이 표시되는 게 아닌, 카테고리 자체 순서대로 조각이 추가되도록
+        
+        data.expenseInfos.forEach { item in
+            guard let type = ExpenseType(rawValue: item.category) else { return }
+            let graphValue = CGFloat(item.cost)
+            
+            if let foundIndex = chartData.firstIndex(where: { $0.category == type }) {
+                chartData[foundIndex].value += graphValue
+            }
+        }
+        chartData = chartData.filter { $0.value != 0 }
+        
+        if !chartData.isEmpty { self.pieChartData = chartData }
+    }
+    
+    /// 막대 차트의 데이터를 설정한다.
+    /// - Parameter data: 원본 지출 데이터
+    private func setupBarChartData(with data: ExpenseListViewModelProtocol) {
+        let expenseData = data.expenseInfos.sorted { $0.date < $1.date }
+        var chartData: [CustomChartItem] = []
+        
+        expenseData.forEach { item in
+            let graphValue = CGFloat(item.cost)
+            
+            if let foundIndex = chartData.firstIndex(where: {$0.date == item.date }) {
+                chartData[foundIndex].value += graphValue
+            } else {
+                chartData.append(CustomChartItem(date: item.date, value: graphValue))
+            }
+        }
+        chartData.sort { ($0.date ?? Date()) < ($1.date ?? Date()) }
+        
+        if !chartData.isEmpty { self.barChartData = chartData }
+    }
+
+}
+
+extension ExpenseChartView {
+    static let dummyData = [
+        CustomChartItem(
+            category: .food,
+            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            value: 70
+        ),
+        CustomChartItem(
+            category: .shopping,
+            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            value: 30
+        ),
+        CustomChartItem(
+            category: .transportation,
+            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            value: 50
+        ),
+        CustomChartItem(
+            category: .room,
+            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            value: 60
+        ),
+        CustomChartItem(
+            category: .other,
+            date: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
+            value: 20
+        )
+    ]
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
@@ -1,0 +1,148 @@
+//
+//  BarBackgroundLayer.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/11/30.
+//
+
+import UIKit
+
+final class BarBackgroundLayer: CAShapeLayer {
+    
+    // MARK: - Properties
+    
+    private let rect: CGRect
+    
+    private let inset: CGSize
+    
+    private let criteria: [Date]
+    
+    private let maxCost: CGFloat
+    
+    /// maxCost를 기준으로 0 ~ maxCost 사이의 값을 n등분하여 배열로 저장하는 프로퍼티. 0과 maxCost는 포함되지 않고 사잇값만 저장한다.
+    private var costStandards: [CGFloat] {
+        var array: [CGFloat] = []
+        for order in 1 ..< Metric.dividerCount {
+            array.append(maxCost / CGFloat(Metric.dividerCount) * CGFloat(order))
+        }
+        
+        return array
+    }
+    
+    private var dataRect: CGRect {
+        return CGRect(
+            x: rect.minX + inset.width,
+            y: rect.minY + inset.height,
+            width: rect.width - inset.width,
+            height: rect.height - 2 * inset.height
+        )
+    }
+    
+    // MARK: - Init
+    
+    init(rect: CGRect, inset: CGSize, criteria: [Date], maxCost: CGFloat) {
+        self.rect = rect
+        self.inset = inset
+        self.criteria = criteria
+        self.maxCost = maxCost
+        
+        super.init()
+        
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Configure Functions
+    
+    private func configure() {
+        configureBackgroundPath()
+        configureAttributes()
+        configureSubLayers()
+    }
+    
+    /// 막대 차트의 배경 라인을 그린다.
+    private func configureBackgroundPath() {
+        let columnRowPath = UIBezierPath()
+        
+        columnRowPath.move(to: CGPoint(x: dataRect.maxX, y: dataRect.maxY))
+        columnRowPath.addLine(to: CGPoint(x: dataRect.minX, y: dataRect.maxY))
+        columnRowPath.addLine(to: CGPoint(x: dataRect.minX, y: dataRect.minY))
+        
+        UIColor.clear.set()
+        
+        path = columnRowPath.cgPath
+    }
+    
+    /// 배경 라인의 속성값을 지정한다.
+    private func configureAttributes() {
+        lineWidth = Metric.lineWidth
+        fillColor = UIColor.white?.cgColor
+        strokeColor = UIColor.grey2?.cgColor
+    }
+    
+    /// 배경에 날짜, 금액 단위를 텍스트로 표시한다.
+    private func configureSubLayers() {
+        for index in criteria.indices {
+            configureDateTextLayer(with: index)
+        }
+        
+        for index in costStandards.indices {
+            configureCostTextLayer(with: index)
+        }
+    }
+    
+    /// 배경의 하단에 차트 데이터 값이 존재하는 날짜를 표시한다.
+    private func configureDateTextLayer(with index: Int) {
+        let textWidth = (rect.width - inset.width) / CGFloat(criteria.count)
+        let textHeight = inset.height
+        let baseX = rect.minX + inset.width
+        
+        let dateTextFrame = CGRect(
+            x: baseX + textWidth * CGFloat(index),
+            y: rect.maxY - textHeight,
+            width: textWidth,
+            height: textHeight
+        )
+        
+        let dateTextLayer = BarTextLayer(
+            rect: dateTextFrame,
+            text: Date.yearMonthDaySplitDashDateFormatter.string(from: criteria[index])
+        )
+        addSublayer(dateTextLayer)
+    }
+    
+    /// 배경의 좌측에 최고 금액을 기준으로 나눈 금액 단위를 표시한다.
+    private func configureCostTextLayer(with index: Int) {
+        let costWidth = inset.width
+        let costHeight = (rect.height - inset.height) / CGFloat(costStandards.count + 1)
+        let baseY = rect.maxY - inset.height
+        
+        let costTextFrame = CGRect(
+            x: rect.minX,
+            y: baseY - costHeight * CGFloat(index + 1),
+            width: costWidth,
+            height: costHeight
+        )
+        
+        let costTextLayer = BarTextLayer(
+            rect: costTextFrame,
+            text: Int(costStandards[index]).numberFormatter(),
+            textFontSize: 9
+        )
+        addSublayer(costTextLayer)
+    }
+}
+
+// MARK: - Namespaces
+
+extension BarBackgroundLayer {
+    enum Metric {
+        static let dividerCount = 5
+        static let lineWidth: CGFloat = 2
+        static let textFontSize: CGFloat = 14
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarShapeLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarShapeLayer.swift
@@ -1,0 +1,86 @@
+//
+//  BarShapeLayer.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/11/30.
+//
+
+import UIKit
+
+final class BarShapeLayer: CAShapeLayer {
+    
+    // MARK: - Properties
+    
+    private let rect: CGRect
+    
+    private let color: CGColor
+    
+    private let value: CGFloat
+    
+    // MARK: - Init
+    
+    init(rect: CGRect, color: CGColor, value: CGFloat) {
+        self.rect = rect
+        self.color = color
+        self.value = value
+        
+        super.init()
+        
+        configure()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Configure Functions
+    
+    private func configure() {
+        configurePath()
+        configureAttributes()
+    }
+    
+    private func configurePath() {
+        let barPath = UIBezierPath()
+        
+        barPath.move(to: CGPoint(x: rect.midX, y: rect.maxY))
+        barPath.addLine(to: CGPoint(x: rect.midX, y: rect.maxY - value))
+        
+        UIColor.clear.set()
+        barPath.stroke()
+        
+        path = barPath.cgPath
+    }
+    
+    private func configureAttributes() {
+        lineWidth = min(rect.width * Metric.widthRatio, Metric.defaultBarWidth)
+        strokeColor = color
+    }
+    
+    // MARK: - Animation Functions
+    
+    func addAnimation() {
+        let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
+        animation.fromValue = Metric.animationFromValue
+        animation.toValue = Metric.animationToValue
+        animation.duration = Metric.animationDuration
+        
+        add(animation, forKey: animation.keyPath)
+    }
+}
+
+extension BarShapeLayer {
+    enum Metric {
+        static let defaultBarWidth: CGFloat = 70
+        static let widthRatio: CGFloat = 0.7
+        
+        static let animationFromValue: CGFloat = 0
+        static let animationToValue: CGFloat = 1
+        static let animationDuration: CGFloat = 1
+    }
+    
+    enum StringLiteral {
+        static let animationKey = "strokeEnd"
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
@@ -1,0 +1,66 @@
+//
+//  BarTextLayer.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/11/30.
+//
+
+import UIKit
+
+final class BarTextLayer: CATextLayer {
+    
+    // MARK: - Properties
+    
+    private let rect: CGRect
+    
+    private let text: String
+    
+    private let textFontSize: CGFloat?
+    
+    // MARK: - Init
+    
+    init(rect: CGRect, text: String, textFontSize: CGFloat? = nil) {
+        self.rect = rect
+        self.text = text
+        self.textFontSize = textFontSize
+        
+        super.init()
+        
+        configureFrame()
+        configureText()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    // MARK: - Configure Functions
+    
+    /// 표시할 텍스트 레이어의 위치, 크기를 지정한다.
+    private func configureFrame() {
+        frame = rect
+    }
+    
+    /// 표시할 텍스트의 크기, 색상을 지정한다.
+    private func configureText() {
+        let attributedString = NSAttributedString(
+            string: text,
+            attributes: [
+                .font: UIFont.boldSystemFont(ofSize: textFontSize ?? Metric.textFontSize),
+                .foregroundColor: UIColor.grey3 ?? UIColor()
+            ]
+        )
+        string = attributedString
+        alignmentMode = .center
+    }
+}
+
+// MARK: - Namespaces
+
+extension BarTextLayer {
+    enum Metric {
+        static let textFontSize: CGFloat = 14
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -12,7 +12,7 @@ final class CustomBarChart: UIView {
 
     // MARK: - Properties
 
-    private var items: [CustomChartItem] = []
+    private var items: [CustomChartItem<Date>] = []
     
     private var isAnimating: Bool = false
 
@@ -30,7 +30,7 @@ final class CustomBarChart: UIView {
     /// - Parameters:
     ///   - data: 차트 데이터 값의 배열
     convenience init(
-        items: [CustomChartItem],
+        items: [CustomChartItem<Date>],
         frame: CGRect = .zero
     ) {
         self.init(frame: frame)
@@ -94,7 +94,7 @@ final class CustomBarChart: UIView {
 
     /// 차트를 표시하는 데이터를 변경할 경우 실행하는 메서드. 데이터를 설정하고 차트를 다시 그린다.
     /// - Parameter data: 변경할 차트 데이터
-    func setupData(with data: [CustomChartItem]) {
+    func setupData(with data: [CustomChartItem<Date>]) {
         self.items = data
         self.isAnimating = !data.isEmpty
 

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -59,8 +59,23 @@ final class CustomBarChart: UIView {
     /// 주어진 rect에 맞게 막대 차트를 그린다. 막대 차트는 영역에 꽉 채워서 그려진다.
     /// - Parameter rect: 막대 차트를 그릴 영역.
     override func draw(_ rect: CGRect) {
+        // 차트 배경 그리기
+        let criteria = items.map { $0.criterion }
+        let backgroundLayer = BarBackgroundLayer(
+            rect: rect,
+            inset: Metric.chartInset,
+            criteria: criteria,
+            maxCost: max
+        )
+        layer.addSublayer(backgroundLayer)
+        
         // 차트 데이터 그리기
-        let dataRect = rect.insetBy(dx: 10, dy: 20)
+        let dataRect = CGRect(
+            x: rect.minX + Metric.chartInset.width,
+            y: rect.minY + Metric.chartInset.height,
+            width: rect.width - Metric.chartInset.width,
+            height: rect.height - 2 * Metric.chartInset.height
+        )
         for idx in items.indices {
             drawOneBar(at: idx, on: dataRect)
         }
@@ -119,4 +134,10 @@ final class CustomBarChart: UIView {
         })
     }
     
+}
+
+extension CustomBarChart {
+    enum Metric {
+        static let chartInset = CGSize(width: 50, height: 30)
+    }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -100,4 +100,23 @@ final class CustomBarChart: UIView {
 
         setNeedsDisplay()
     }
+    
+    // MARK: - Animation Functions
+    
+    /// 외부의 값 변화로 인해 애니메이션을 재실행할 경우 활용할 수 있는 메서드.
+    /// 이전에 등록된 서브레이어들을 모두 제거한 후 화면을 다시 그린다.
+    func executeAnimation() {
+        removeAllSubLayers()
+        setNeedsDisplay()
+    }
+    
+    // MARK: - Layer Functions
+    
+    /// 레이어에 등록되어 있던 모든 서브 레이어들을 제거한다.
+    private func removeAllSubLayers() {
+        layer.sublayers?.forEach({ layer in
+            layer.removeFromSuperlayer()
+        })
+    }
+    
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -1,0 +1,103 @@
+//
+//  CustomBarChart.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/11/30.
+//
+
+import UIKit
+
+/// Custom Bar Chart
+final class CustomBarChart: UIView {
+
+    // MARK: - Properties
+
+    private var items: [CustomChartItem] = []
+    
+    private var isAnimating: Bool = false
+
+    private var max: CGFloat {
+        return items.max(by: { $0.value < $1.value })?.value ?? 0
+    }
+    
+    // MARK: - Animation Properties
+    
+    
+
+    // MARK: - Init
+
+    /// 막대 차트를 그릴 기반이 되는 데이터 값의 배열을 받아 차트 화면을 생성한다.
+    /// - Parameters:
+    ///   - data: 차트 데이터 값의 배열
+    convenience init(
+        items: [CustomChartItem],
+        frame: CGRect = .zero
+    ) {
+        self.init(frame: frame)
+        self.items = items
+    }
+
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configureBackgroundColor()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: - Configure Functions
+
+    private func configureBackgroundColor() {
+        backgroundColor = .white
+    }
+
+    // MARK: - Draw Functions
+
+    /// 주어진 rect에 맞게 막대 차트를 그린다. 막대 차트는 영역에 꽉 채워서 그려진다.
+    /// - Parameter rect: 막대 차트를 그릴 영역.
+    override func draw(_ rect: CGRect) {
+        // 차트 데이터 그리기
+        let dataRect = rect.insetBy(dx: 10, dy: 20)
+        for idx in items.indices {
+            drawOneBar(at: idx, on: dataRect)
+        }
+    }
+    
+    /// 막대 차트 중 하나의 막대를 그려 서브레이어로 추가한다.
+    /// - Parameters:
+    ///   - index: 그릴 막대의 순서
+    ///   - rect: 막대를 그릴 영역
+    private func drawOneBar(at index: Int, on rect: CGRect) {
+        let value = items[index].value
+        let barWidth = rect.width / CGFloat(items.count)
+        let barLayerFrame = CGRect(
+            x: rect.minX + barWidth * CGFloat(index),
+            y: rect.minY,
+            width: barWidth,
+            height: rect.height
+        )
+        let barLayer = BarShapeLayer(
+            rect: barLayerFrame,
+            color: UIColor.primaryOrange?.cgColor ?? UIColor().cgColor,
+            value: value * (rect.height / max)
+        )
+
+        layer.addSublayer(barLayer)
+        
+        if isAnimating { barLayer.addAnimation() }
+    }
+    
+    // MARK: - Setup Data & Redraw Functions
+
+    /// 차트를 표시하는 데이터를 변경할 경우 실행하는 메서드. 데이터를 설정하고 차트를 다시 그린다.
+    /// - Parameter data: 변경할 차트 데이터
+    func setupData(with data: [CustomChartItem]) {
+        self.items = data
+        self.isAnimating = !data.isEmpty
+
+        setNeedsDisplay()
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
@@ -7,16 +7,17 @@
 
 import Foundation
 
-struct CustomChartItem {
-    let category: ExpenseType?
-    let date: Date?
+struct CustomChartItem<T: Equatable> {
+    
+    /// 차트데이터를 구분 짓는 기준이 되는 값.
+    /// 원형 차트에서는 ExpenseType이, 막대 차트에서는 Date가 기준이 된다.
+    let criterion: T
     
     /// 차트 데이터 값
     var value: CGFloat
     
-    init(category: ExpenseType? = nil, date: Date? = nil, value: CGFloat) {
-        self.category = category
-        self.date = date
+    init(criterion: T, value: CGFloat) {
+        self.criterion = criterion
         self.value = value
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
@@ -8,14 +8,15 @@
 import Foundation
 
 struct CustomChartItem {
-    // TODO: 막대 차트에서도 사용할 거라면 category 대신 다른 걸 사용해야함. 막대 차트는 카테고리 기준이 아니니까..!
-    let category: ExpenseType
+    let category: ExpenseType?
+    let date: Date?
     
     /// 차트 데이터 값
     var value: CGFloat
     
-    init(category: ExpenseType, value: CGFloat) {
+    init(category: ExpenseType? = nil, date: Date? = nil, value: CGFloat) {
         self.category = category
+        self.date = date
         self.value = value
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -76,11 +76,12 @@ final class CustomPieChart: UIView {
     }
     
     private func drawOnePiece(with item: CustomChartItem, on rect: CGRect) {
+        guard let category = item.category else { return }
         let pieceLayer = PieceShapeLayer(
             rect: rect,
             startAngle: startAngle,
             angleRatio: ratio * Metric.angle,
-            color: item.category.color.cgColor
+            color: category.color.cgColor
         )
         layer.addSublayer(pieceLayer)
         
@@ -88,7 +89,7 @@ final class CustomPieChart: UIView {
         let textLayer = PieceTextLayer(
             center: CGPoint(x: rect.width/2, y: rect.height/2),
             pieceBounds: boundingBox,
-            text: "\(item.category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
+            text: "\(category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
         )
         layer.addSublayer(textLayer)
         
@@ -105,17 +106,6 @@ final class CustomPieChart: UIView {
         backgroundColor = .white
     }
     
-    /// 파이 조각별 애니메이션 설정
-    private func configureLayerAnimation() -> CABasicAnimation {
-        let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
-        animation.fromValue = Metric.animationFromValue
-        animation.toValue = Metric.animationToValue
-        animation.duration = ratio * Metric.animationDuration
-        animation.delegate = self
-        
-        return animation
-    }
-    
     // MARK: - Setup Data & Redraw Functions
     
     /// 차트를 표시하는 데이터를 변경할 경우 실행하는 메서드. 데이터를 설정하고 차트를 다시 그린다.
@@ -128,9 +118,39 @@ final class CustomPieChart: UIView {
         setNeedsDisplay()
     }
     
+    // MARK: - Animation Functions
+    
     private func initializeAnimation() {
         startAngle = Metric.initialStartAngle
         currentIndex = 0
+    }
+    
+    /// 파이 조각별 애니메이션 설정
+    private func configureLayerAnimation() -> CABasicAnimation {
+        let animation = CABasicAnimation(keyPath: StringLiteral.animationKey)
+        animation.fromValue = Metric.animationFromValue
+        animation.toValue = Metric.animationToValue
+        animation.duration = ratio * Metric.animationDuration
+        animation.delegate = self
+        
+        return animation
+    }
+    
+    /// 외부의 값 변화로 인해 애니메이션을 재실행할 경우 활용할 수 있는 메서드.
+    /// 이전에 등록된 서브레이어들을 모두 제거하고, 애니메이션 설정 값들을 초기화 한 후 `draw(_:)`메서드를 재실행한다.
+    func executeAnimation() {
+        removeAllSubLayers()
+        initializeAnimation()
+        setNeedsDisplay()
+    }
+    
+    // MARK: - Layer Functions
+    
+    /// 레이어에 등록되어 있던 모든 서브 레이어들을 제거한다.
+    private func removeAllSubLayers() {
+        layer.sublayers?.forEach({ layer in
+            layer.removeFromSuperlayer()
+        })
     }
     
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -14,7 +14,7 @@ final class CustomPieChart: UIView {
     
     // MARK: - Properties
     
-    private var items: [CustomChartItem] = []
+    private var items: [CustomChartItem<ExpenseType>] = []
     
     private var isAnimating: Bool = false
     
@@ -28,7 +28,7 @@ final class CustomPieChart: UIView {
     
     private var currentIndex = 0
     
-    private var currentItem: CustomChartItem { items[currentIndex] }
+    private var currentItem: CustomChartItem<ExpenseType> { items[currentIndex] }
     
     private var ratio: CGFloat { currentItem.value / total }
     
@@ -38,7 +38,7 @@ final class CustomPieChart: UIView {
     /// - Parameters:
     ///   - data: 차트 데이터 값의 배열
     convenience init(
-        items: [CustomChartItem],
+        items: [CustomChartItem<ExpenseType>],
         frame: CGRect = .zero
     ) {
         self.init(frame: frame)
@@ -75,8 +75,8 @@ final class CustomPieChart: UIView {
 
     }
     
-    private func drawOnePiece(with item: CustomChartItem, on rect: CGRect) {
-        guard let category = item.category else { return }
+    private func drawOnePiece(with item: CustomChartItem<ExpenseType>, on rect: CGRect) {
+        let category = item.criterion
         let pieceLayer = PieceShapeLayer(
             rect: rect,
             startAngle: startAngle,
@@ -110,7 +110,7 @@ final class CustomPieChart: UIView {
     
     /// 차트를 표시하는 데이터를 변경할 경우 실행하는 메서드. 데이터를 설정하고 차트를 다시 그린다.
     /// - Parameter data: 변경할 차트 데이터
-    func setupData(with data: [CustomChartItem]) {
+    func setupData(with data: [CustomChartItem<ExpenseType>]) {
         self.items = data
         self.isAnimating = !data.isEmpty
         initializeAnimation()

--- a/Doesaegim/Doesaegim/Utility/ExpenseType.swift
+++ b/Doesaegim/Doesaegim/Utility/ExpenseType.swift
@@ -7,14 +7,6 @@
 
 import UIKit
 
-// TODO: - 정수로 관리하고싶음
-//enum ExpenseType: Int {
-//    case food = 0
-//    case transportation = 1
-//    case room = 2
-//    case other = 3
-//}
-
 // MARK: - ExpenseType: 지금은 문자열로 구분
 
 enum ExpenseType: String, CaseIterable {


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- 날짜를 기준으로 지출 내역을 표시하는 막대 그래프와 애니메이션을 구현했습니다.
  - 막대 그래프의 경우 단순 막대와 지출 일자만 표시하기에는 사용자에게 제공되는 정보가 부족할 것이라는 생각이 들어 좌측에 금액 단위를 추가로 표시했습니다.
- 두 차트가 각각 다른 기준으로 데이터를 표현하지만 기존의 `CustomChartItem`를 동일하게 활용하고 싶어 제네릭 타입으로 수정해 리팩토링했습니다.
- `UISegmentedControl`을 도입하여 카테고리별과 날짜별로 보이는 그래프가 다르게 표시되도록 구현했습니다.
  - 또한, `UISegmentedControl`의 값이 변경될 때마다 그래프의 애니메이션이 다시 재생되도록 구현했습니다.
  - `UISegmentedControl`과 그래프 뷰를 합쳐 별도의 뷰 `ExpenseChartView`로 분리해 컬렉션 헤더뷰의 코드양을 줄였습니다.

## 관련 이슈
- resolves #49
- resolves #102  

## 리뷰노트
> 고민, 과정, 궁금한점

### 애니메이션 재실행 관련 - 해결
세그먼트 컨트롤의 선택된 인덱스 값이 변경될 때마다 애니메이션이 재생되도록 구현하는 과정에서 약간의 어려움이 있었습니다.
레이어의 애니메이션을 동작시키기 위해서는 애니메이션을 생성하고, 이를 레이어에 추가해주는 과정을 거쳐야 헀는데요,

이러한 상황에서 세그먼트 컨트롤의 값이 변경될 때마다 애니메이션을 생성해 추가해주는 건 **각각의 레이어가 중복된 애니메이션을 여러 개 갖게 되어** 좋지 않다고 생각하기도 했고, 무엇보다 기존에 추가된 서브 레이어들이 이미 밑에 깔려 있어 **애니메이션이 동작하고 있어도 동작하지 않는 것처럼 보이는 문제**가 있었습니다. 

이를 해결하기 위해서는 **기존의 서브 레이어들을 모두 제거하는 과정**이 두 그래프에 공통적으로 필요했고, 원형 그래프의 경우 조각을 순차적으로 표시하기 위해 애니메이션이 동작하고 있는 조각의 순서를 별도로 저장하도록 해두었는데, **이를 0번째로 초기화**하는 과정이 필요하다고 생각했습니다. 

원형 그래프의 애니메이션 순서 초기화 메서드는 initializeAnimation로 이미 구현을 해 둔 상황이었고, 서브 레이어를 모두 제거하는 메서드만 하나 더 구현 후 애니메이션을 새롭게 생성하여 추가하는 대신 `setNeedsDisplay`를 통해 화면을 다시 그리게 함으로써 문제를 해결했습니다.

### 금액 단위 관련 - 고민 중..
현재 막대 그래프에서는 `0원~ 최고 금액 사이의 범위`에서 단순히 5등분한 값들을 금액 단위로 취급해 그래프 좌측에 표시해주고 있는데요, 이 최고 금액이라는 게 1원 단위까지 값이 있으면 금액 단위가 깔끔하게 떨어지지 않아서 최고 금액을 어느 정도 반올림해서 거기서 5등분을 해야하나 하고 고민 중에 있습니다. 일단은 반올림까지는 하지 않고 그대로 표시해두었습니다🥲

### 0%에 가까운 지출 비율의 텍스트 표시 - 고민 중..
스크린샷에서 보여지고 있듯이 현재는 아무리 적은 비율이라도 지출 내역이 있으면 그래프에 표시해주고 있는 상황인데, 위치 표시가 애매하기도 하고 이 정도로 적은 건 지출 내역에서 보이는 것으로도 충분하지 않나? 하는 생각이 들어서 이것도 같이 고민 중입니다..

## 스크린샷

https://user-images.githubusercontent.com/50136980/204841711-1f5e61ec-f4ae-46b2-b7ac-77bbf191bcb9.mp4

