### PR TITLE
[커스텀 캘린더] 일요일 날짜 Label이 붉은색으로 나타나지 않는 오류 수정

### DIFF
--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellViewModel.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendarCellViewModel.swift
@@ -24,7 +24,7 @@ final class CustomCalendarCellViewModel: CustomCalendarCellProtocol {
     func checkDateIsSunday(to date: Date) {
         let calendar = Calendar.current
         let week = calendar.component(.weekday, from: date)
-        isSunday = week == 2
+        isSunday = week == 1
     }
     
 }


### PR DESCRIPTION
## 변경사항
* `calendar.component(.weekday, from: date)` 값이 1이면 일요일로 표시되도록 변경했습니다.

## 리뷰노트
* 원래는 `calendar.component(.weekday, from: date)` 값이 2일때 일요일로 표시되도록 구현이 되어있었는데, 분명 구현했을 때는 정상작동을 했었는데, 어디선가 잘못된 점이 더 있을 것 같은데 아직 정확하게 파악이 되지는 않았습니다.. ㅠ 

## 스크린샷
|수정 전|수정 후|
|---|---|
}![스크린샷 2022-12-01 오전 11 29 32](https://user-images.githubusercontent.com/77199797/204965260-d00f7570-dd8d-4c55-a2de-401c0de869b7.png)|![스크린샷 2022-12-01 오전 11 35 42](https://user-images.githubusercontent.com/77199797/204965018-8998b60b-30e7-4989-b6ad-a75262d5e919.png)|
