### PR TITLE
[커스텀 그래프 리팩토링] 버그 일부 수정 및 리팩토링

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		B53763D5292B61A40073BF46 /* CustomChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763D4292B61A40073BF46 /* CustomChartItem.swift */; };
 		B53763E3292B99B80073BF46 /* PieceShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */; };
 		B53763E8292BA0760073BF46 /* PieceTextLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E7292BA0760073BF46 /* PieceTextLayer.swift */; };
+		B5716134293CE56E002FDC35 /* CustomChartType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5716133293CE56E002FDC35 /* CustomChartType.swift */; };
 		B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D96252922301E00B510B8 /* TravelDTO.swift */; };
 		B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D9627292230CA00B510B8 /* PlanDTO.swift */; };
 		B57D962C2922315500B510B8 /* LocationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D962B2922315500B510B8 /* LocationDTO.swift */; };
@@ -236,6 +237,7 @@
 		B53763D4292B61A40073BF46 /* CustomChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChartItem.swift; sourceTree = "<group>"; };
 		B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceShapeLayer.swift; sourceTree = "<group>"; };
 		B53763E7292BA0760073BF46 /* PieceTextLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceTextLayer.swift; sourceTree = "<group>"; };
+		B5716133293CE56E002FDC35 /* CustomChartType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChartType.swift; sourceTree = "<group>"; };
 		B57D96252922301E00B510B8 /* TravelDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDTO.swift; sourceTree = "<group>"; };
 		B57D9627292230CA00B510B8 /* PlanDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDTO.swift; sourceTree = "<group>"; };
 		B57D962B2922315500B510B8 /* LocationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDTO.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 		B53763C8292B56600073BF46 /* CustomGraph */ = {
 			isa = PBXGroup;
 			children = (
+				B5716133293CE56E002FDC35 /* CustomChartType.swift */,
 				B53763D4292B61A40073BF46 /* CustomChartItem.swift */,
 				B53763E4292B99D10073BF46 /* PieChart */,
 				B5B497C929374BDC009AE4AC /* BarChart */,
@@ -1420,6 +1423,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE3FB85929375C960024AEE1 /* SharePopoverViewController.swift in Sources */,
+				B5716134293CE56E002FDC35 /* CustomChartType.swift in Sources */,
 				B5C421A4292F204900963B17 /* ExpenseAddPickerViewController.swift in Sources */,
 				B5C421A3292F201700963B17 /* ExpenseAddPickerViewProtocol.swift in Sources */,
 				EEA1C826292F4E6000B80901 /* ExchangeMemoryCache.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -43,15 +43,17 @@ final class ExpenseChartView: UIView {
     
     /// 원형 차트 데이터
     private var pieChartData: [CustomChartItem<ExpenseType>] = ExpenseChartView.pieChartDummies {
-        didSet {
-            pieChart.setupData(with: pieChartData)
+        willSet {
+            guard pieChartData != newValue else { return }
+            pieChart.setupData(with: newValue)
         }
     }
     
     /// 막대 차트 데이터
     private var barChartData: [CustomChartItem<Date>] = [] {
-        didSet {
-            barChart.setupData(with: barChartData)
+        willSet {
+            guard barChartData != newValue else { return }
+            barChart.setupData(with: newValue)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -43,17 +43,15 @@ final class ExpenseChartView: UIView {
     
     /// 원형 차트 데이터
     private var pieChartData: [CustomChartItem<ExpenseType>] = ExpenseChartView.pieChartDummies {
-        willSet {
-            guard pieChartData != newValue else { return }
-            pieChart.setupData(with: newValue)
+        didSet {
+            pieChart.setupData(with: pieChartData)
         }
     }
     
     /// 막대 차트 데이터
     private var barChartData: [CustomChartItem<Date>] = [] {
-        willSet {
-            guard barChartData != newValue else { return }
-            barChart.setupData(with: newValue)
+        didSet {
+            barChart.setupData(with: barChartData)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -43,15 +43,17 @@ final class ExpenseChartView: UIView {
     
     /// 원형 차트 데이터
     private var pieChartData: [CustomChartItem<ExpenseType>] = ExpenseChartView.pieChartDummies {
-        didSet {
-            pieChart.setupData(with: pieChartData)
+        willSet {
+            guard pieChartData != newValue else { return }
+            pieChart.setupData(with: newValue)
         }
     }
     
     /// 막대 차트 데이터
     private var barChartData: [CustomChartItem<Date>] = [] {
-        didSet {
-            barChart.setupData(with: barChartData)
+        willSet {
+            guard barChartData != newValue else { return }
+            barChart.setupData(with: newValue)
         }
     }
     
@@ -116,6 +118,7 @@ final class ExpenseChartView: UIView {
         barChart.isHidden = !pieChart.isHidden
         
         if !pieChart.isHidden {
+            
             pieChart.executeAnimation()
         } else {
             barChart.executeAnimation()
@@ -168,7 +171,6 @@ final class ExpenseChartView: UIView {
             }
         }
         chartData.sort { $0.criterion < $1.criterion }
-        
         if !chartData.isEmpty { self.barChartData = chartData }
     }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseChartView.swift
@@ -12,8 +12,8 @@ final class ExpenseChartView: UIView {
     // MARK: - UI Properties
     
     private let segmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: ["카테고리별", "날짜별"])
-        control.selectedSegmentIndex = 0
+        let control = UISegmentedControl(items: CustomChartType.allCases.map { $0.title })
+        control.selectedSegmentIndex = CustomChartType.pie.rawValue
         
         return control
     }()
@@ -49,7 +49,7 @@ final class ExpenseChartView: UIView {
     }
     
     /// 막대 차트 데이터
-    private var barChartData: [CustomChartItem<Date>] = ExpenseChartView.barChartDummies {
+    private var barChartData: [CustomChartItem<Date>] = [] {
         didSet {
             barChart.setupData(with: barChartData)
         }
@@ -94,7 +94,7 @@ final class ExpenseChartView: UIView {
     /// 초기에 화면 진입 시 어떤 차트를 보여줄 것인지 지정한다.
     private func configureInitialChartView() {
         pieChart.isHidden = false
-        barChart.isHidden = true
+        barChart.isHidden = !pieChart.isHidden
     }
     
     /// 세그먼티드 컨트롤에 액션을 추가한다.
@@ -112,7 +112,7 @@ final class ExpenseChartView: UIView {
     @objc func segmentedControlValueDidChange() {
         let selectedIndex = segmentedControl.selectedSegmentIndex
         
-        pieChart.isHidden = selectedIndex == 0 ? false : true
+        pieChart.isHidden = selectedIndex != CustomChartType.pie.rawValue
         barChart.isHidden = !pieChart.isHidden
         
         if !pieChart.isHidden {
@@ -161,7 +161,7 @@ final class ExpenseChartView: UIView {
         expenseData.forEach { item in
             let graphValue = CGFloat(item.cost)
             
-            if let foundIndex = chartData.firstIndex(where: {$0.criterion == item.date }) {
+            if let foundIndex = chartData.firstIndex(where: { $0.criterion == item.date }) {
                 chartData[foundIndex].value += graphValue
             } else {
                 chartData.append(CustomChartItem(criterion: item.date, value: graphValue))
@@ -181,28 +181,5 @@ extension ExpenseChartView {
         CustomChartItem(criterion: .transportation, value: 50),
         CustomChartItem(criterion: .room, value: 60),
         CustomChartItem(criterion: .other, value: 20)
-    ]
-    
-    static let barChartDummies: [CustomChartItem<Date>] = [
-        CustomChartItem(
-            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
-            value: 70
-        ),
-        CustomChartItem(
-            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
-            value: 30
-        ),
-        CustomChartItem(
-            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
-            value: 50
-        ),
-        CustomChartItem(
-            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
-            value: 60
-        ),
-        CustomChartItem(
-            criterion: Date.yearMonthDateFormatter.date(from: "2022-11-30") ?? Date(),
-            value: 20
-        )
     ]
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -254,7 +254,10 @@ extension ExpenseListViewController: ExpenseListViewModelDelegate {
             snapshot.appendItems([info], toSection: dateString)
         }
         
-        expenseDataSource?.apply(snapshot)
+        expenseDataSource?.apply(snapshot, completion: { [weak self] in
+            self?.expenseCollectionView.reloadData()
+        })
+
     }
     
     func expenseListFetchDidFail() {

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -113,7 +113,7 @@ final class CustomBarChart: UIView {
         self.items = data
         self.isAnimating = !data.isEmpty
 
-        setNeedsDisplay()
+        executeAnimation()
     }
     
     // MARK: - Animation Functions

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartItem.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CustomChartItem<T: Equatable> {
+struct CustomChartItem<T: Equatable>: Equatable {
     
     /// 차트데이터를 구분 짓는 기준이 되는 값.
     /// 원형 차트에서는 ExpenseType이, 막대 차트에서는 Date가 기준이 된다.

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartType.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/CustomChartType.swift
@@ -1,0 +1,19 @@
+//
+//  CustomChartType.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/12/04.
+//
+
+import Foundation
+
+enum CustomChartType: Int, CaseIterable {
+    case pie, bar
+    
+    var title: String {
+        switch self {
+        case .pie: return "카테고리별"
+        case .bar: return "날짜별"
+        }
+    }
+}

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -124,14 +124,15 @@ final class CustomPieChart: UIView {
     func setupData(with data: [CustomChartItem<ExpenseType>]) {
         self.items = data
         self.isAnimating = !data.isEmpty
-        initializeAnimation()
         
-        setNeedsDisplay()
+        executeAnimation()
     }
     
     // MARK: - Animation Functions
     
+    /// 애니메이션을 초기화하는 메서드. 기존에 추가되었던 서브레이어들을 모두 삭제하고 시작 각도와 애니메이션이 진행되어야할 순서를 초기화한다.
     private func initializeAnimation() {
+        removeAllSubLayers()
         startAngle = Metric.initialStartAngle
         currentIndex = 0
     }
@@ -150,7 +151,6 @@ final class CustomPieChart: UIView {
     /// 외부의 값 변화로 인해 애니메이션을 재실행할 경우 활용할 수 있는 메서드.
     /// 이전에 등록된 서브레이어들을 모두 제거하고, 애니메이션 설정 값들을 초기화 한 후 `draw(_:)`메서드를 재실행한다.
     func executeAnimation() {
-        removeAllSubLayers()
         initializeAnimation()
         setNeedsDisplay()
     }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -85,13 +85,15 @@ final class CustomPieChart: UIView {
         )
         layer.addSublayer(pieceLayer)
         
-        guard let boundingBox = pieceLayer.path?.boundingBox else { return }
-        let textLayer = PieceTextLayer(
-            center: CGPoint(x: rect.width/2, y: rect.height/2),
-            pieceBounds: boundingBox,
-            text: "\(category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
-        )
-        layer.addSublayer(textLayer)
+        if ratio >= Metric.textPresentedPercentage {
+            let textLayer = PieceTextLayer(
+                rect: rect,
+                startAngle: startAngle,
+                angle: ratio * Metric.angle,
+                text: "\(category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
+            )
+            layer.addSublayer(textLayer)
+        }
         
         if isAnimating {
             let pieceAnimation = configureLayerAnimation()
@@ -177,6 +179,9 @@ extension CustomPieChart {
         static let animationFromValue: CGFloat = 0
         static let animationToValue: CGFloat = 1
         static let animationDuration: CGFloat = 1.2
+        
+        /// 텍스트를 표시하는 기준이 되는 파이 차트 조각의 비율. 5%이상일 경우에만 텍스트를 표시한다
+        static let textPresentedPercentage: CGFloat = 0.05
     }
     
     enum StringLiteral {

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -16,14 +16,22 @@ final class CustomPieChart: UIView {
     
     private var items: [CustomChartItem<ExpenseType>] = []
     
-    private var isAnimating: Bool = false
-    
     private var total: CGFloat {
         items.reduce(0) { $0 + $1.value }
     }
     
+    // MARK: - Computed Property
+    
+    private var halfRadius: CGFloat {
+        // 차트뷰가 그려질 뷰의 너비, 높이값이 다를 경우 차트뷰의 지름은 작은 값을 따라간다.
+        let diameter = min(bounds.width, bounds.height)
+        return diameter * Metric.halfRadiusRatio
+    }
+    
     // MARK: - Animation Properties
     
+    private var isAnimating: Bool = false
+
     private var startAngle: CGFloat = Metric.initialStartAngle
     
     private var currentIndex = 0
@@ -78,18 +86,19 @@ final class CustomPieChart: UIView {
     private func drawOnePiece(with item: CustomChartItem<ExpenseType>, on rect: CGRect) {
         let category = item.criterion
         let pieceLayer = PieceShapeLayer(
-            rect: rect,
+            center: center,
+            radius: halfRadius,
             startAngle: startAngle,
-            angleRatio: ratio * Metric.angle,
+            angle: ratio * Metric.angle,
             color: category.color.cgColor
         )
         layer.addSublayer(pieceLayer)
         
         if ratio >= Metric.textPresentedPercentage {
             let textLayer = PieceTextLayer(
-                rect: rect,
-                startAngle: startAngle,
-                angle: ratio * Metric.angle,
+                center: center,
+                radius: halfRadius * 2,
+                angle: startAngle + (ratio * Metric.angle / 2),
                 text: "\(category.rawValue)\n\(String(format: "%.2f", ratio * 100))%"
             )
             layer.addSublayer(textLayer)
@@ -182,6 +191,8 @@ extension CustomPieChart {
         
         /// 텍스트를 표시하는 기준이 되는 파이 차트 조각의 비율. 5%이상일 경우에만 텍스트를 표시한다
         static let textPresentedPercentage: CGFloat = 0.05
+        
+        static let halfRadiusRatio: CGFloat = 0.23
     }
     
     enum StringLiteral {

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceShapeLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceShapeLayer.swift
@@ -11,36 +11,27 @@ final class PieceShapeLayer: CAShapeLayer {
     
     // MARK: - Properties
     
-    private let rect: CGRect
+    private let center: CGPoint
+    
+    private let radius: CGFloat
     
     private let startAngle: CGFloat
     
-    private let angleRatio: CGFloat
+    private let angle: CGFloat
     
     private let color: CGColor
     
     // MARK: - Computed Properties
     
-    private var center: CGPoint {
-        return CGPoint(x: rect.midX, y: rect.midY)
-    }
-    
-    private var radius: CGFloat {
-        // 차트뷰가 그려질 뷰의 너비, 높이값이 다를 경우 차트뷰의 지름은 작은 값을 따라간다.
-        let diameter = min(rect.width, rect.height)
-        return diameter * Metric.radiusRatio
-    }
-    
-    private var strokeWidth: CGFloat {
-        return radius * 2
-    }
+    private var strokeWidth: CGFloat { radius * 2 }
     
     // MARK: - Init
     
-    init(rect: CGRect, startAngle: CGFloat, angleRatio: CGFloat, color: CGColor) {
-        self.rect = rect
+    init(center: CGPoint, radius: CGFloat, startAngle: CGFloat, angle: CGFloat, color: CGColor) {
+        self.center = center
+        self.radius = radius
         self.startAngle = startAngle
-        self.angleRatio = angleRatio
+        self.angle = angle
         self.color = color
         
         super.init()
@@ -62,7 +53,7 @@ final class PieceShapeLayer: CAShapeLayer {
             arcCenter: center,
             radius: radius,
             startAngle: startAngle,
-            endAngle: startAngle + angleRatio,
+            endAngle: startAngle + angle,
             clockwise: true
         )
         UIColor.clear.set()

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
@@ -11,20 +11,35 @@ final class PieceTextLayer: CATextLayer {
     
     // MARK: - Properties
     
-    /// 파이 차트의 중심값
-    private let center: CGPoint
+    /// 파이 차트의 영역값
+    private let rect: CGRect
     
-    /// 파이 조각이 그려진 영역 값
-    private let pieceBounds: CGRect
+    /// 텍스트를 표시할 조각의 시작 지점 각도
+    private let startAngle: CGFloat
+    
+    /// 텍스트를 표시할 조각의 자체 각도.
+    private let angle: CGFloat
     
     /// 파이 조각에 표시할 텍스트
     private let text: String
     
+    // MARK: - Computed Properties
+        
+    private var center: CGPoint {
+        return CGPoint(x: rect.midX, y: rect.midY)
+    }
+    
+    private var radius: CGFloat {
+        let diameter = min(rect.width, rect.height)
+        return diameter * Metric.radiusRatio
+    }
+    
     // MARK: - Init
     
-    init(center: CGPoint, pieceBounds: CGRect, text: String) {
-        self.center = center
-        self.pieceBounds = pieceBounds
+    init(rect: CGRect, startAngle: CGFloat, angle: CGFloat, text: String) {
+        self.rect = rect
+        self.startAngle = startAngle
+        self.angle = angle
         self.text = text
         
         super.init()
@@ -43,18 +58,15 @@ final class PieceTextLayer: CATextLayer {
     
     /// 표시할 텍스트 레이어의 위치, 크기를 지정한다.
     private func configureFrame() {
-        let spacing = CGPoint(
-            x: pieceBounds.width * 0.1,
-            y: pieceBounds.height * 0.1
-        )
-        let xPosition = configureXPosition(with: spacing.x)
-        let yPosition = configureYPosition(with: spacing.y)
+        let textPosition = configurePosition()
+        let textSize = CGSize(width: Metric.textWidth, height: fontSize * 1.5)
         
         let textFrame = CGRect(
-            x: xPosition,
-            y: yPosition,
-            width: Metric.textWidth,
-            height: fontSize * 2
+            origin: CGPoint(
+                x: textPosition.x - textSize.width / 2,
+                y: textPosition.y - textSize.height / 2
+            ),
+            size: textSize
         )
         frame = textFrame
     }
@@ -72,39 +84,25 @@ final class PieceTextLayer: CATextLayer {
         alignmentMode = .left
     }
     
-    // TODO: configureXPosition, configureYPosition 겹치는 부분 합치고 싶은데 가능할까..
-    
-    /// 텍스트가 표시될 위치의 x 좌표 값을 구해 반환한다.
-    /// - Parameter spacing: 파이 차트 중심에서 떨어질 정도 값
-    /// - Returns: 텍스트가 표시될 x 좌표 값
-    private func configureXPosition(with spacing: CGFloat) -> CGFloat {
-        let leftSide: CGFloat = abs(center.x - pieceBounds.minX)
-        let rightSide: CGFloat = abs(center.x - pieceBounds.maxX)
+    /// 파이 조각의 중간 위치 값을 구해 반환한다. 해당 위치는 텍스트의 midX, midY 좌표값이 된다.
+    private func configurePosition() -> CGPoint {
+        let halfAngle: CGFloat = startAngle + angle / 2
         
-        let baseXPosition = leftSide < rightSide ? pieceBounds.midX : pieceBounds.minX
-        let multiplier: CGFloat = leftSide < rightSide ? 1 : -1
+        let xCoordinate = center.x + cos(halfAngle) * radius * Metric.positionRatio
+        let yCoordinate = center.y + sin(halfAngle) * radius * Metric.positionRatio
         
-        return baseXPosition + multiplier * spacing
+        return CGPoint(x: xCoordinate, y: yCoordinate)
     }
     
-    /// 텍스트가 표시될 위치의 y 좌표 값을 구해 반환한다.
-    /// - Parameter spacing: 파이 차트 중심에서 떨어질 정도 값
-    /// - Returns: 텍스트가 표시될 y 좌표 값
-    private func configureYPosition(with spacing: CGFloat) -> CGFloat {
-        let topSide: CGFloat = abs(center.y - pieceBounds.minY)
-        let bottomSide: CGFloat = abs(center.y - pieceBounds.maxY)
-        
-        let baseYPosition = topSide < bottomSide ? pieceBounds.midY : pieceBounds.minY
-        let multiplier: CGFloat = topSide < bottomSide ? -1 : 1
-        print(multiplier)
-        
-        return baseYPosition + multiplier * spacing
-    }
 }
 
 extension PieceTextLayer {
     enum Metric {
+        static let radiusRatio: CGFloat = 0.4
+
         static let textWidth: CGFloat = 60
         static let textFontSize: CGFloat = 16
+        
+        static let positionRatio: CGFloat = 0.7
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
@@ -11,34 +11,23 @@ final class PieceTextLayer: CATextLayer {
     
     // MARK: - Properties
     
-    /// 파이 차트의 영역값
-    private let rect: CGRect
+    /// 파이 차트의 중심값
+    private let center: CGPoint
     
-    /// 텍스트를 표시할 조각의 시작 지점 각도
-    private let startAngle: CGFloat
+    /// 파이 조각의 반지름
+    private let radius: CGFloat
     
-    /// 텍스트를 표시할 조각의 자체 각도.
+    /// 텍스트를 표시할 지점의 각도.
     private let angle: CGFloat
     
     /// 파이 조각에 표시할 텍스트
     private let text: String
     
-    // MARK: - Computed Properties
-        
-    private var center: CGPoint {
-        return CGPoint(x: rect.midX, y: rect.midY)
-    }
-    
-    private var radius: CGFloat {
-        let diameter = min(rect.width, rect.height)
-        return diameter * Metric.radiusRatio
-    }
-    
     // MARK: - Init
     
-    init(rect: CGRect, startAngle: CGFloat, angle: CGFloat, text: String) {
-        self.rect = rect
-        self.startAngle = startAngle
+    init(center: CGPoint, radius: CGFloat, angle: CGFloat, text: String) {
+        self.center = center
+        self.radius = radius
         self.angle = angle
         self.text = text
         
@@ -81,15 +70,13 @@ final class PieceTextLayer: CATextLayer {
             ]
         )
         string = attributedString
-        alignmentMode = .left
+        alignmentMode = .center
     }
     
     /// 파이 조각의 중간 위치 값을 구해 반환한다. 해당 위치는 텍스트의 midX, midY 좌표값이 된다.
     private func configurePosition() -> CGPoint {
-        let halfAngle: CGFloat = startAngle + angle / 2
-        
-        let xCoordinate = center.x + cos(halfAngle) * radius * Metric.positionRatio
-        let yCoordinate = center.y + sin(halfAngle) * radius * Metric.positionRatio
+        let xCoordinate = center.x + cos(angle) * radius * Metric.positionRatio
+        let yCoordinate = center.y + sin(angle) * radius * Metric.positionRatio
         
         return CGPoint(x: xCoordinate, y: yCoordinate)
     }


### PR DESCRIPTION
## 변경사항
- 파이 차트의 조각 레이어와 텍스트 레이어에서 공통으로 구현되어 있는 프로퍼티들을 차트 자체에서 관리하도록 수정했습니다.
- 파이 차트가 화면에서 보이지 않았다가 다시 보이게 되었을 때 동일한 레이어가 중복으로 쌓이는 문제를 수정했습니다.
- 파이 차트의 텍스트 위치를 최종적으로 조정했습니다. ~~진짜_최종~~
- 지출 추가 후 파이 차트가 갱신되지 않는 문제를 수정했습니다.

## 리뷰노트
- 이전에는 PieceShapeLayer와 PieceTextLayer 클래스로 전체 차트가 그려질 영역값을 받아와 내부에서 각각 center, radius 프로퍼티를 계산하도록 했지만, 비효율적인 과정이라고 생각되어 처음부터 차트 클래스에서 center와 radius 값을 계산해 각 레이어 클래스 생성 인자로 보내도록 수정했습니다.

- 아래의 첫번째 스크린샷을 확인해보면 다른 화면으로 이동했다가 다시 지출 조회 화면으로 돌아왔을 때 색이 물결치는 듯한 효과를 확인할 수 있는데, 처음 진입했을 때 그려졌던 차트 위에 동일한 차트가 다시 쌓여 발생하는 문제였습니다. 
  - 애니메이션을 실행하는 메서드인 `executeAnimation`에 기존의 모든 서브레이어를 삭제하는 메서드인 `removeAllLayers`를 추가하고, 이 `executeAnimation`을 `setupData`에 추가함으로써 문제를 해결했습니다.


- 텍스트 위치를 적절하게 조정하기 위해 다음과 같은 계산식을 적용했습니다. (feat. 결국 사용하게 된 삼각함수)
<img src="https://user-images.githubusercontent.com/50136980/205644781-8821e255-2a42-41cc-beb9-e37ce7726853.jpg" width="65%">

- 중심각 θ를 갖는 부채꼴에서 원의 중심으로부터 0.7 * radius 만큼 떨어져 있는 위치에 텍스트를 표시하기 위해 다음과 같이 x, y좌표를 구하고 이를 적용했습니다.
  - 찾아봤던 레퍼런스 자료들이 더 복잡한 게 많아서 삼각함수 사용을 꺼려왔던 건데, 생각보다 간단하게 구현해서 진작 이렇게 하지 않은 것을 후회하고 있습니다..

- 지출 추가 후 그래프가 갱신되지 않는 문제를 해결하기 위해 `expenseDataSource.apply` 메서드의 completion handler에서 `reloadData`를 수행하도록 했습니다.

## 스크린샷
첫번째 스크린샷이 동일한 레이어가 중복으로 쌓여 문제가 되는 모습이고, 두번째 스크린샷이 문제 해결 후 모습입니다!
(버그 수정 결과 확인을 위해 임시 데이터와 `applySnapshotUsingReloadData` 메서드를 활용했습니다.)

https://user-images.githubusercontent.com/50136980/205648151-9fbda496-8c54-4831-904e-d28eee51b0e6.mp4

https://user-images.githubusercontent.com/50136980/205677730-a76e6c21-720d-446e-a857-9c061fde1be2.mp4
