### PR TITLE
[리팩토링] 이미지 메모리캐시 구현

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		BB02B092292F295800FE11DA /* DiaryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B091292F295800FE11DA /* DiaryListViewModel.swift */; };
 		BB02B094292F29E000FE11DA /* DiaryListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */; };
 		BB02B096292F2A4900FE11DA /* DiaryInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B095292F2A4900FE11DA /* DiaryInfoViewModel.swift */; };
+		BB0A8287293F29FA0014056C /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0A8286293F29FA0014056C /* ImageCacheManager.swift */; };
 		BB288FC8292E167900065D04 /* DiaryCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FC7292E167900065D04 /* DiaryCalloutView.swift */; };
 		BB288FCB292E1A2B00065D04 /* FileProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FCA292E1A2B00065D04 /* FileProcessManager.swift */; };
 		BB288FD0292E21E100065D04 /* FileManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FCF292E21E100065D04 /* FileManagerError.swift */; };
@@ -269,6 +270,7 @@
 		BB02B091292F295800FE11DA /* DiaryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModel.swift; sourceTree = "<group>"; };
 		BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModelProtocol.swift; sourceTree = "<group>"; };
 		BB02B095292F2A4900FE11DA /* DiaryInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryInfoViewModel.swift; sourceTree = "<group>"; };
+		BB0A8286293F29FA0014056C /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		BB288FC7292E167900065D04 /* DiaryCalloutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCalloutView.swift; sourceTree = "<group>"; };
 		BB288FCA292E1A2B00065D04 /* FileProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProcessManager.swift; sourceTree = "<group>"; };
 		BB288FCF292E21E100065D04 /* FileManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerError.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				EEB6C4FC292CC29B0060A459 /* NetworkManager.swift */,
 				BB288FCA292E1A2B00065D04 /* FileProcessManager.swift */,
 				EE3FB8482935E1660024AEE1 /* ShareManager.swift */,
+				BB0A8286293F29FA0014056C /* ImageCacheManager.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1516,6 +1519,7 @@
 				B5D64E63292DF06400E1CC81 /* DiaryAddView.swift in Sources */,
 				A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */,
 				B5D64E78292E4B9A00E1CC81 /* DetailImageCell.swift in Sources */,
+				BB0A8287293F29FA0014056C /* ImageCacheManager.swift in Sources */,
 				B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */,
 				BB288FCB292E1A2B00065D04 /* FileProcessManager.swift in Sources */,
 				EEA1C824292F395100B80901 /* ExchangeDiskCache.swift in Sources */,

--- a/Doesaegim/Doesaegim/Services/FileProcessManager.swift
+++ b/Doesaegim/Doesaegim/Services/FileProcessManager.swift
@@ -56,13 +56,26 @@ extension FileProcessManager {
     func fetchImages(with imagePaths: [String], diaryID: UUID) -> [Data] {
         var imageDatas: [Data] = []
         imagePaths.forEach { imagePath in
-            let result = fetchImage(with: imagePath, diaryID: diaryID)
-            switch result {
+            let cacheResult = ImageCacheManager.loadImage(with: imagePath)
+            
+            switch cacheResult {
             case .success(let data):
                 imageDatas.append(data)
+                
             case .failure(let error):
                 print(error.localizedDescription)
-                // TODO: - 에러처리
+                
+                let result = fetchImage(with: imagePath, diaryID: diaryID)
+                
+                switch result {
+                case .success(let data):
+                    imageDatas.append(data)
+                    ImageCacheManager.addImage(with: imagePath, data: data)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                    // TODO: - 에러처리
+                }
+                
             }
         }
         return imageDatas

--- a/Doesaegim/Doesaegim/Services/ImageCacheManager.swift
+++ b/Doesaegim/Doesaegim/Services/ImageCacheManager.swift
@@ -1,0 +1,49 @@
+//
+//  ImageCacheManager.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/06.
+//
+
+import UIKit
+
+
+final class ImageCacheManager {
+    
+    static let shared = NSCache<NSString, UIImage>()
+    
+    private init() {  }
+}
+
+// MARK: - Image
+
+extension ImageCacheManager {
+    
+    static func loadImage(with path: String) -> Result<UIImage, Error> {
+        let cacheKey = NSString(string: path)
+        guard let cacheImage = ImageCacheManager.shared.object(forKey: cacheKey) else {
+            return .failure(CacheError.canNotFindImageError)
+        }
+        
+        return .success(cacheImage)
+    }
+    
+    static func addImage(with path: String, image: UIImage) {
+        ImageCacheManager.shared.setObject(image, forKey: NSString(string: path))
+    }
+    
+}
+
+enum CacheError: LocalizedError {
+    case canNotFindImageError
+    case canNotFindImageURLFromPathString
+    
+    var errorDescription: String? {
+        switch self {
+        case .canNotFindImageError:
+            return "이미지가 캐시에 존재하지 않습니다."
+        case .canNotFindImageURLFromPathString:
+            return "잘못된 이미지경로 URL 형식입니다."
+        }
+    }
+}

--- a/Doesaegim/Doesaegim/Services/ImageCacheManager.swift
+++ b/Doesaegim/Doesaegim/Services/ImageCacheManager.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class ImageCacheManager {
     
-    static let shared = NSCache<NSString, UIImage>()
+    static let shared = NSCache<NSString, NSData>()
     
     private init() {  }
 }
@@ -19,17 +19,18 @@ final class ImageCacheManager {
 
 extension ImageCacheManager {
     
-    static func loadImage(with path: String) -> Result<UIImage, Error> {
+    static func loadImage(with path: String) -> Result<Data, Error> {
         let cacheKey = NSString(string: path)
-        guard let cacheImage = ImageCacheManager.shared.object(forKey: cacheKey) else {
+        guard let cacheData = ImageCacheManager.shared.object(forKey: cacheKey) else {
             return .failure(CacheError.canNotFindImageError)
         }
-        
-        return .success(cacheImage)
+        let cacheImageData = Data(referencing: cacheData)
+        return .success(cacheImageData)
     }
     
-    static func addImage(with path: String, image: UIImage) {
-        ImageCacheManager.shared.setObject(image, forKey: NSString(string: path))
+    static func addImage(with path: String, data: Data) {
+        let imageData = NSData(data: data)
+        ImageCacheManager.shared.setObject(imageData, forKey: NSString(string: path))
     }
     
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 이미지의 메모리 캐시를 구현하고, 이미 캐시에 저장된 이미지일 경우 캐시에 있는 이미지를 사용합니다.
- 조회했던 다이어리를 다시 조회할 경우 이미지를 불러오는 시간을 15배정도 향상시켰습니다.

## 리뷰노트
> 고민, 과정, 궁금한점

## 스크린샷

캐시 사용 전
![image](https://user-images.githubusercontent.com/76734067/205928042-9bc4e413-fd85-45da-ad25-b3ce8ead5a58.png)

캐시 사용 후
![image](https://user-images.githubusercontent.com/76734067/205928151-095de37b-7dca-4ac7-bd2e-2874dcd57d9c.png)


