### PR TITLE
[다이어리 목록] 다이어리 셀과 헤더가 매칭되지 않는 버그 수정

### DIFF
--- a/Doesaegim/Doesaegim/Data/ViewModel/DiaryInfoViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/DiaryInfoViewModel.swift
@@ -12,6 +12,7 @@ struct DiaryInfoViewModel: Hashable {
     
     var travelID: UUID?
     var travelName: String?
+    var travelDate: Date?
     let id: UUID
     let content: String
     let date: Date

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/DiaryListViewModelProtocol.swift
@@ -10,9 +10,10 @@ import Foundation
 protocol DiaryListViewModelProtocol: AnyObject {
     
     var delegate: DiaryListViewModelDelegate? { get set }
-    var travelSections: [String] { get set }
-    var diaryInfos: [DiaryInfoViewModel] { get set }
-    var sectionDiaryDictionary: [Int: [DiaryInfoViewModel]] { get set }
+//    var travelSections: [String] { get set }
+//    var diaryInfos: [DiaryInfoViewModel] { get set }
+//    var sectionDiaryDictionary: [Int: [DiaryInfoViewModel]] { get set }
+    var travelDiaryInfos: [(startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel])] { get set }
     
     func fetchDiary()
     func addDummyDiaryData() // 추후 삭제

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListViewController.swift
@@ -179,10 +179,10 @@ extension DiaryListViewController {
             )
             
             guard let viewModel = self?.viewModel,
-                  let travelName = viewModel.travelSections[safeIndex: indexPath.section] else {
+                  let travelDiaryInfo = viewModel.travelDiaryInfos[safeIndex: indexPath.section] else {
                 return UICollectionReusableView()
             }
-
+            let travelName = travelDiaryInfo.travelName
             sectionHeader.configureData(with: travelName)
             
             return sectionHeader
@@ -195,13 +195,15 @@ extension DiaryListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: - 다이어리 선택 뷰, safe index 설정
         guard let viewModel = viewModel,
-              indexPath.row < viewModel.diaryInfos.count,
-              let diary = viewModel.sectionDiaryDictionary[indexPath.section] else { return }
+              let travelDiaryInfo = viewModel.travelDiaryInfos[safeIndex: indexPath.section],
+              let diary = travelDiaryInfo.diaryInfos[safeIndex: indexPath.row] else { return }
+        // sectionDictionary는 Array가 아니라 Dictionary이기 때문에 safeIndex가 적용되지 않는다.
+        // 어차피 없는 Key값이라면 nil이 반환되기 때문에 indexPath.section이 올바른 범위에 있는지도 확인할 필요가 없다.
         
         // uuid를 생성자에 넘기고 다이어리 디테일 뷰 푸시
         let section = indexPath.section
         let row = indexPath.row
-        let uuid = diary[row].id
+        let uuid = diary.id
         
         let controller = DiaryDetailViewController(id: uuid)
         navigationController?.pushViewController(controller, animated: true)
@@ -214,20 +216,20 @@ extension DiaryListViewController: DiaryListViewModelDelegate {
     
     func diaryInfoDidChage() {
         guard let viewModel = viewModel else { return }
-        let diaryInfos = viewModel.diaryInfos
         
-        placeholdLabel.isHidden = diaryInfos.isEmpty ? false : true
+        let travelDiaryInfos = viewModel.travelDiaryInfos
+        placeholdLabel.isHidden = travelDiaryInfos.isEmpty ? false : true
+        
         var snapshot = SnapShot()
         
-        diaryInfos.forEach { info in
-            guard let travelName = info.travelName else { return }
-            if !snapshot.sectionIdentifiers.contains(travelName) {
-                snapshot.appendSections([travelName])
-            }
-            snapshot.appendItems([info], toSection: travelName)
+        travelDiaryInfos.forEach { (startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel]) in
+            // 여행종류마다 튜플로 구분되어 있으므로, 해당 섹션이 이미 존재하는지 확인할 필요가 없다. 없음이 명확하다.
+            snapshot.appendSections([travelName])
+            snapshot.appendItems(diaryInfos, toSection: travelName)
         }
         
         diaryDataSource?.apply(snapshot, animatingDifferences: true)
+        
     }
     
     func diaryListFetchDidFail() {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -10,19 +10,15 @@ import Foundation
 final class DiaryListViewModel: DiaryListViewModelProtocol {
     
     var delegate: DiaryListViewModelDelegate?
-    var travelSections: [String]
-    var diaryInfos: [DiaryInfoViewModel] { // 여행UUID: 다이어리 목록
+    var travelDiaryInfos: [(startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel])] {
         didSet {
             delegate?.diaryInfoDidChage()
         }
     }
-    var sectionDiaryDictionary: [Int: [DiaryInfoViewModel]]
     var currentTravel: Travel? // 추후 삭제될 코드
     
     init() {
-        self.diaryInfos = []
-        self.travelSections = []
-        self.sectionDiaryDictionary = [:]
+        self.travelDiaryInfos = []
     }
     
 }
@@ -30,9 +26,7 @@ final class DiaryListViewModel: DiaryListViewModelProtocol {
 extension DiaryListViewModel {
     
     private func initializeInfo() {
-        diaryInfos = []
-        travelSections = []
-        sectionDiaryDictionary = [:]
+        travelDiaryInfos.removeAll()
     }
     
     func fetchDiary() {
@@ -49,32 +43,30 @@ extension DiaryListViewModel {
         let travelFetchResult = PersistentRepository.shared.fetchTravel()
         switch travelFetchResult {
         case .success(let travels):
-            var newDiaries: [DiaryInfoViewModel] = []
+            
+            // TODO: - let으로 바꾸기 위해 고차함수를 사용할 수 있나?
+            var newInfos: [(startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel])] = []
             travels.forEach { travel in
                 // travel안의 diary데이터를 받아온다.
-                guard let diaries = travel.diary?.allObjects as? [Diary] else { return }
-                diaries.forEach { diary in
-                    guard var diaryInfo = Diary.convertToViewModel(with: diary) else { return }
-                    guard let travelID = travel.id,
-                          let name = travel.name else { return }
-                    diaryInfo.travelID = travelID
-                    diaryInfo.travelName = name
-                    newDiaries.append(diaryInfo)
-                    
-                    if !travelSections.contains(name) {
-                        travelSections.append(name)
-                    }
-                    
-                    guard let section = travelSections.firstIndex(of: name) else { return }
-                    sectionDiaryDictionary[section, default: []].append(diaryInfo)
-                }
+                guard let id = travel.id,
+                      let diaries = travel.diary?.allObjects as? [Diary],
+                      let travelName = travel.name,
+                      let startDate = travel.startDate else { return }
+            
+                // Diary를 DiaryInfoViewModel로 변환
+                let diaryInfos = diaries.compactMap({
+                    Diary.convertToViewModel(with: $0, id: id, name: travelName, startAt: startDate)
+                })
+                
+                newInfos.append((startDate: startDate,travelName: travelName, diaryInfos: diaryInfos))
+            
                 // TODO: - 추후삭제
                 if currentTravel == nil {
                     currentTravel = travel
                 }
             }
-            newDiaries = newDiaries.sorted(by: sortByDate)
-            diaryInfos = newDiaries
+            travelDiaryInfos = newInfos
+            travelDiaryInfos.sorted(by: sortByDate)
             
         case .failure(let error):
             print(error.localizedDescription)
@@ -106,12 +98,19 @@ extension DiaryListViewModel {
         }
     }
     
-    private func sortByDate(_ lhs: DiaryInfoViewModel, _ rhs: DiaryInfoViewModel) -> Bool {
-        let formatter = Date.yearTominuteFormatterWithoutSeparator
-        let date1 = formatter.string(from: lhs.date)
-        let date2 = formatter.string(from: rhs.date)
-        
-        return date1 > date2
+//    private func sortByDate(_ lhs: DiaryInfoViewModel, _ rhs: DiaryInfoViewModel) -> Bool {
+//        let formatter = Date.yearTominuteFormatterWithoutSeparator
+//        let date1 = formatter.string(from: lhs.date)
+//        let date2 = formatter.string(from: rhs.date)
+//
+//        return date1 > date2
+//    }
+    
+    private func sortByDate(
+        _ lhs: (startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel]),
+        _ rhs: (startDate: Date, travelName: String, diaryInfos: [DiaryInfoViewModel])
+    ) -> Bool {
+        return lhs.startDate > rhs.startDate
     }
     
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -65,8 +65,7 @@ extension DiaryListViewModel {
                     currentTravel = travel
                 }
             }
-            travelDiaryInfos = newInfos
-            travelDiaryInfos.sorted(by: sortByDate)
+            travelDiaryInfos = newInfos.sorted(by: sortByDate)
             
         case .failure(let error):
             print(error.localizedDescription)

--- a/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
@@ -70,7 +70,12 @@ public class Diary: NSManagedObject {
         return diaryMapInfo
     }
     
-    static func convertToViewModel(with diary: Diary) -> DiaryInfoViewModel? {
+    static func convertToViewModel(
+        with diary: Diary,
+        id: UUID,
+        name: String,
+        startAt startDate: Date) -> DiaryInfoViewModel? {
+            
         guard let id = diary.id,
               let title = diary.title,
               let content = diary.content,
@@ -88,13 +93,17 @@ public class Diary: NSManagedObject {
             }
         }
         
-        let diaryInfo = DiaryInfoViewModel(
+        var diaryInfo = DiaryInfoViewModel(
             id: id,
             content: content,
             date: date,
             imageData: imageData,
             title: title
         )
+            
+        diaryInfo.travelID = id
+        diaryInfo.travelName = name
+        diaryInfo.travelDate = date
         
         return diaryInfo
     }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- 다이어리 목록에서 헤더와 셀이 매치되지 않는 버그를 수정하였습니다.

## 리뷰노트
> 고민, 과정, 궁금한점

- 딕셔너리의 겨우 삽입한 순서대로 삽입되지 않고, 다이어리 정보를 관리하던 **배열**은 정보를 순서대로 저장했기에 이에 순서정보가 충돌하여서 발생한 버그였습니다. 
- 기존에는 여행의 이름과 디어일 정보를 `[(여행이름 문자열): (여행의 다이어리 정보)]`와 같은 사전정보로 관리하고 있었습니다. 그리고 발견된 여행들마다 몇번째 섹션의 여행 제목은 ~~~이군 과 같은 정보도 사전으로 관리하고 있었습니다. 
- 하지만 사전에 데이터를 특정 순서대로 저장했다고 해도, 조회할때도 순서대로 읽어올 것을 보장하지는 않습니다.
- 다이어리에 대한 정보는 배열에 받아온 순서대로 저장하였습니다.
- 이 사전과 다이어리 배열정보를 같이 읽어오면서 인덱스가 서로의 정보가 아닌점이 문제였습니다.

- 같은 여행의 정보만 담을 수 있으면서 순서도 지켜주는 자료형이 무엇이있을까 고민을 하다가 튜플의 배열을 떠올렸습니다.
- 결국에는 배열이라서 여행정보가 저장되는것과 동일하고, 게다가 튜플의 원소중하나로 다이어리의 정보배열을 넣어주면 다이어리정보배열을 따로 빼서 관리할 필요도 없어집니다.
- 마지막에 여행의 시작일을 기준으로 내림차순으로 정렬해주는 작업만 추가하였습니다.

## 스크린샷
<img width="300" src="https://user-images.githubusercontent.com/76734067/205994373-07cca4fc-a49d-4b63-905a-d132da15446c.jpeg">
