### PR TITLE
[설정화면] 설정화면의 기본적인 UI구현

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -789,8 +789,8 @@
 		BB305CBB2940844A006C3480 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				BB305CBC29408457006C3480 /* SettingViewModel.swift */,
 				BB305CBE294084BC006C3480 /* SettingViewModelProtocol.swift */,
+				BB305CBC29408457006C3480 /* SettingViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -92,6 +92,10 @@
 		BB288FC8292E167900065D04 /* DiaryCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FC7292E167900065D04 /* DiaryCalloutView.swift */; };
 		BB288FCB292E1A2B00065D04 /* FileProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FCA292E1A2B00065D04 /* FileProcessManager.swift */; };
 		BB288FD0292E21E100065D04 /* FileManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB288FCF292E21E100065D04 /* FileManagerError.swift */; };
+		BB305CB929408410006C3480 /* SettingOptionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB305CB829408410006C3480 /* SettingOptionViewModel.swift */; };
+		BB305CBD29408457006C3480 /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB305CBC29408457006C3480 /* SettingViewModel.swift */; };
+		BB305CBF294084BC006C3480 /* SettingViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB305CBE294084BC006C3480 /* SettingViewModelProtocol.swift */; };
+		BB305CC129408639006C3480 /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB305CC029408639006C3480 /* SettingTableViewCell.swift */; };
 		BB3DB919292C649600C70D62 /* UIView+Frame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3DB918292C649600C70D62 /* UIView+Frame.swift */; };
 		BB3DB91E292C83C400C70D62 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3DB91D292C83C400C70D62 /* MapViewModel.swift */; };
 		BB3DB920292CA76800C70D62 /* MapViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3DB91F292CA76800C70D62 /* MapViewModelProtocol.swift */; };
@@ -286,6 +290,10 @@
 		BB288FC7292E167900065D04 /* DiaryCalloutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryCalloutView.swift; sourceTree = "<group>"; };
 		BB288FCA292E1A2B00065D04 /* FileProcessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProcessManager.swift; sourceTree = "<group>"; };
 		BB288FCF292E21E100065D04 /* FileManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagerError.swift; sourceTree = "<group>"; };
+		BB305CB829408410006C3480 /* SettingOptionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingOptionViewModel.swift; sourceTree = "<group>"; };
+		BB305CBC29408457006C3480 /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
+		BB305CBE294084BC006C3480 /* SettingViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModelProtocol.swift; sourceTree = "<group>"; };
+		BB305CC029408639006C3480 /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
 		BB3DB918292C649600C70D62 /* UIView+Frame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Frame.swift"; sourceTree = "<group>"; };
 		BB3DB91D292C83C400C70D62 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		BB3DB91F292CA76800C70D62 /* MapViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -479,7 +487,8 @@
 		A4CC04B1292261E800BB678B /* SettingScene */ = {
 			isa = PBXGroup;
 			children = (
-				BBD0D062291DE991007D0D82 /* SettingViewController.swift */,
+				BB305CBB2940844A006C3480 /* ViewModel */,
+				BB305CBA2940843E006C3480 /* View */,
 			);
 			path = SettingScene;
 			sourceTree = "<group>";
@@ -768,6 +777,24 @@
 			path = Errors;
 			sourceTree = "<group>";
 		};
+		BB305CBA2940843E006C3480 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				BBD0D062291DE991007D0D82 /* SettingViewController.swift */,
+				BB305CC029408639006C3480 /* SettingTableViewCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		BB305CBB2940844A006C3480 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				BB305CBC29408457006C3480 /* SettingViewModel.swift */,
+				BB305CBE294084BC006C3480 /* SettingViewModelProtocol.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		BB323E3329231DF100DFABC0 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -848,6 +875,7 @@
 				BB3DB921292CA79500C70D62 /* DiaryMapInfoViewModel.swift */,
 				BB02B095292F2A4900FE11DA /* DiaryInfoViewModel.swift */,
 				BBD97AC92936110500D1AF44 /* DetectInfoViewModel.swift */,
+				BB305CB829408410006C3480 /* SettingOptionViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1522,6 +1550,7 @@
 				A4EB25CD292C9775002D129A /* TemporaryDiary.swift in Sources */,
 				EEDB75312925F56D0069A7F5 /* CalendarProtocol.swift in Sources */,
 				A4CC04D32923308600BB678B /* DateCollectionHeaderView.swift in Sources */,
+				BB305CBD29408457006C3480 /* SettingViewModel.swift in Sources */,
 				A4CC04CF292281B400BB678B /* UIStackView+AddArrangedSubviews.swift in Sources */,
 				BBEC31FA2934B40B0064CCFA /* CGImagePropertyOrientation+.swift in Sources */,
 				A4CC04CB29227E5C00BB678B /* Constants.swift in Sources */,
@@ -1549,6 +1578,7 @@
 				B5B497D6293777EE009AE4AC /* ExpenseChartView.swift in Sources */,
 				BB3DB926292CF89400C70D62 /* DiaryAnnotation.swift in Sources */,
 				A4CC04D1292324B000BB678B /* EmptyLabeledCollectionView.swift in Sources */,
+				BB305CB929408410006C3480 /* SettingOptionViewModel.swift in Sources */,
 				BBEEFA8A29376BC8005DEF38 /* UIImage+.swift in Sources */,
 				BBFAC08B291CBDD700D7FD57 /* MainTabBarController.swift in Sources */,
 				A4EB25C2292BB518002D129A /* DiaryAddLocalRepository.swift in Sources */,
@@ -1623,10 +1653,12 @@
 				A4CC04D72923347E00BB678B /* PlanListViewController.swift in Sources */,
 				EE3FB85E2938738A0024AEE1 /* TravelAddView.swift in Sources */,
 				A48E9946292512BC0029D57D /* CoreDataError.swift in Sources */,
+				BB305CC129408639006C3480 /* SettingTableViewCell.swift in Sources */,
 				BB9DB8102928D09200102EC8 /* PersistentRepository.swift in Sources */,
 				BBB31A3E2926007D00C9E3A9 /* ExpenseListViewController.swift in Sources */,
 				BB6079B3292F546900BF30C8 /* DiaryListHeaderView.swift in Sources */,
 				B53763E8292BA0760073BF46 /* PieceTextLayer.swift in Sources */,
+				BB305CBF294084BC006C3480 /* SettingViewModelProtocol.swift in Sources */,
 				BBD0D066291DED6A007D0D82 /* UIColor+.swift in Sources */,
 				BBD97ACA2936110500D1AF44 /* DetectInfoViewModel.swift in Sources */,
 				BBB31A402926008D00C9E3A9 /* ExpenseListViewModel.swift in Sources */,

--- a/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  SettingOptionViewModel.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/07.
+//
+
+import UIKit
+
+
+struct SettingOptionViewModel {
+    
+    let title: String
+    let icon: UIImage?
+    let iconTintColor: UIColor?
+    let handler: (() -> Void)
+    
+}

--- a/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
@@ -17,7 +17,7 @@ struct SettingOptionViewModel {
     
 }
 
-enum SettringOptionType {
+enum SettingOptionType {
     case staticCell(model: SettingOptionViewModel)
     case switchCell(model: SettingOptionViewModel)
 }

--- a/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/SettingOptionViewModel.swift
@@ -16,3 +16,8 @@ struct SettingOptionViewModel {
     let handler: (() -> Void)
     
 }
+
+enum SettringOptionType {
+    case staticCell(model: SettingOptionViewModel)
+    case switchCell(model: SettingOptionViewModel)
+}

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/SettingViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/SettingViewController.swift
@@ -9,9 +9,66 @@ import UIKit
 
 final class SettingViewController: UIViewController {
     
+    private let tableView: UITableView = {
+        let table = UITableView()
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        
+        return table
+    }()
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemPurple
     }
 
+}
+
+extension SettingViewController {
+    
+    private func configure() {
+        
+        configureNavigationBar()
+        configureTableView()
+        configureSubviews()
+        configureConstraints()
+        
+    }
+    
+    private func configureNavigationBar() {
+        navigationItem.title = "설정"
+    }
+    
+    private func configureTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.frame = view.bounds
+    }
+    
+    private func configureSubviews() {
+        
+    }
+    
+    private func configureConstraints() {
+        
+    }
+    
+    
+    
+}
+
+extension SettingViewController: UITableViewDelegate {
+    
+}
+
+extension SettingViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        cell.textLabel?.text = "Hello World"
+        return cell
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
@@ -11,8 +11,6 @@ import UIKit
 import SnapKit
 
 final class SettingTableViewCell: UITableViewCell {
-
-    static let identifier = String(describing: SettingTableViewCell.self)
     
     // 네모뷰 안에 감싸보자!
     private let iconContainerView: UIView = {

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
@@ -36,7 +36,6 @@ final class SettingTableViewCell: UITableViewCell {
         let label = UILabel()
         
         label.numberOfLines = 1
-        label.lineBreakMode = .byTruncatingTail
         
         return label
     }()

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingTableViewCell.swift
@@ -1,0 +1,107 @@
+//
+//  SettingTableViewCell.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/07.
+//
+
+import UIKit
+
+
+import SnapKit
+
+final class SettingTableViewCell: UITableViewCell {
+
+    static let identifier = String(describing: SettingTableViewCell.self)
+    
+    // 네모뷰 안에 감싸보자!
+    private let iconContainerView: UIView = {
+        let view = UIView()
+        
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 7
+        view.layer.masksToBounds = true
+        
+        return view
+    }()
+    
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        imageView.tintColor = .white
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
+    }()
+    
+    private let label: UILabel = {
+        let label = UILabel()
+        
+        label.numberOfLines = 1
+        label.lineBreakMode = .byTruncatingTail
+        
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        configureSubviews()
+        configureConstraints()
+        accessoryType = .disclosureIndicator
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // 리셋
+        iconImageView.image = nil
+        label.text = nil
+        iconContainerView.backgroundColor = nil
+    }
+
+}
+
+extension SettingTableViewCell {
+    
+    func configure(with info: SettingOptionViewModel) {
+        label.text = info.title
+        iconImageView.image = info.icon
+        iconContainerView.backgroundColor = info.iconTintColor
+    }
+    
+    private func configureSubviews() {
+        contentView.addSubview(label)
+        contentView.addSubview(iconContainerView)
+        iconContainerView.addSubview(iconImageView)
+    }
+    
+    private func configureConstraints() {
+        let size = contentView.frame.size.height - 12
+        iconContainerView.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(10)
+            $0.top.equalToSuperview().offset(6)
+            $0.width.height.equalTo(size)
+        }
+        
+        let imageSize = size / 1.5
+        iconImageView.snp.makeConstraints {
+            $0.width.height.equalTo(imageSize)
+            $0.center.equalToSuperview()
+        }
+        
+        label.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(iconContainerView.snp.trailing).offset(15)
+        }
+    }
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
@@ -9,17 +9,20 @@ import UIKit
 
 final class SettingViewController: UIViewController {
     
+    // MARK: - Properties
+    
     private let tableView: UITableView = {
-        let table = UITableView()
-        table.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        table.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.identifier)
         
         return table
     }()
     
+    private let viewModel: SettingViewModelProtocol = SettingViewModel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemPurple
+        configure()
     }
 
 }
@@ -27,7 +30,7 @@ final class SettingViewController: UIViewController {
 extension SettingViewController {
     
     private func configure() {
-        
+        viewModel.configureSettingInfos()
         configureNavigationBar()
         configureTableView()
         configureSubviews()
@@ -46,7 +49,7 @@ extension SettingViewController {
     }
     
     private func configureSubviews() {
-        
+        view.addSubview(tableView)
     }
     
     private func configureConstraints() {
@@ -63,12 +66,20 @@ extension SettingViewController: UITableViewDelegate {
 
 extension SettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        return viewModel.settingInfos.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        cell.textLabel?.text = "Hello World"
+        
+        guard let settingInfo = viewModel.settingInfos[safeIndex: indexPath.row],
+              let cell = tableView.dequeueReusableCell(
+                withIdentifier: SettingTableViewCell.identifier,
+                for: indexPath
+              ) as? SettingTableViewCell else {
+            return UITableViewCell()
+        }
+        
+        cell.configure(with: settingInfo)
         return cell
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
@@ -34,7 +34,6 @@ extension SettingViewController {
         configureNavigationBar()
         configureTableView()
         configureSubviews()
-        configureConstraints()
         
     }
     
@@ -52,12 +51,6 @@ extension SettingViewController {
         view.addSubview(tableView)
     }
     
-    private func configureConstraints() {
-        
-    }
-    
-    
-    
 }
 
 extension SettingViewController: UITableViewDelegate {
@@ -68,10 +61,15 @@ extension SettingViewController: UITableViewDelegate {
               let info = settingInfo.options[safeIndex: indexPath.row] else { return }
         // TODO: - 핸들러 실행 또는 네비게이션 바 이동
         
+        switch info {
+        case .staticCell(let model):
+            model.handler()
+            
+        default:
+            return
+        }
+        
     }
-    
-    
-    
 }
 
 extension SettingViewController: UITableViewDataSource {
@@ -88,16 +86,27 @@ extension SettingViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         guard let settingInfos = viewModel.settingInfos[safeIndex: indexPath.section],
-              let info = settingInfos.options[safeIndex: indexPath.row],
-              let cell = tableView.dequeueReusableCell(
-                withIdentifier: SettingTableViewCell.identifier,
-                for: indexPath
-              ) as? SettingTableViewCell else {
+              let info = settingInfos.options[safeIndex: indexPath.row] else {
             return UITableViewCell()
         }
         
-        cell.configure(with: info)
-        return cell
+        switch info {
+        case .staticCell(let model):
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: SettingTableViewCell.identifier,
+                for: indexPath
+            ) as? SettingTableViewCell else {
+                return UITableViewCell()
+            }
+            cell.configure(with: model)
+            return cell
+            
+        case .switchCell(let model):
+            // TODO: - SwitchCell 설정 알림설정 등
+            return UITableViewCell()
+        }
+        
+        return UITableViewCell()
     }
     
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -105,9 +114,3 @@ extension SettingViewController: UITableViewDataSource {
         return settingInfos.title
     }
 }
-
-struct SettingSection {
-    let title: String
-    let options: [SettingOptionViewModel]
-}
-

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
@@ -62,16 +62,33 @@ extension SettingViewController {
 
 extension SettingViewController: UITableViewDelegate {
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let settingInfo = viewModel.settingInfos[safeIndex: indexPath.section],
+              let info = settingInfo.options[safeIndex: indexPath.row] else { return }
+        // TODO: - 핸들러 실행 또는 네비게이션 바 이동
+        
+    }
+    
+    
+    
 }
 
 extension SettingViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
         return viewModel.settingInfos.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let options = viewModel.settingInfos[safeIndex: section]?.options else { return 0 }
+        return options.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        guard let settingInfo = viewModel.settingInfos[safeIndex: indexPath.row],
+        guard let settingInfos = viewModel.settingInfos[safeIndex: indexPath.section],
+              let info = settingInfos.options[safeIndex: indexPath.row],
               let cell = tableView.dequeueReusableCell(
                 withIdentifier: SettingTableViewCell.identifier,
                 for: indexPath
@@ -79,7 +96,18 @@ extension SettingViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         
-        cell.configure(with: settingInfo)
+        cell.configure(with: info)
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard let settingInfos = viewModel.settingInfos[safeIndex: section] else { return nil }
+        return settingInfos.title
+    }
 }
+
+struct SettingSection {
+    let title: String
+    let options: [SettingOptionViewModel]
+}
+

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/View/SettingViewController.swift
@@ -13,7 +13,7 @@ final class SettingViewController: UIViewController {
     
     private let tableView: UITableView = {
         let table = UITableView(frame: .zero, style: .insetGrouped)
-        table.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.identifier)
+        table.register(SettingTableViewCell.self, forCellReuseIdentifier: SettingTableViewCell.name)
         
         return table
     }()
@@ -93,7 +93,7 @@ extension SettingViewController: UITableViewDataSource {
         switch info {
         case .staticCell(let model):
             guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: SettingTableViewCell.identifier,
+                withIdentifier: SettingTableViewCell.name,
                 for: indexPath
             ) as? SettingTableViewCell else {
                 return UITableViewCell()

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class SettingViewModel: SettingViewModelProtocol {
     
-    var settingInfos: [SettingOptionViewModel] = [SettingOptionViewModel]()
+    var settingInfos: [SettingSection] = [SettingSection]()
     
 }
 
@@ -21,20 +21,37 @@ extension SettingViewModel {
     func configureSettingInfos() {
         // 배열 삽입 시작
         settingInfos = [
-            SettingOptionViewModel(
-                title: "날짜/시간표시",
-                icon: UIImage(systemName: "house"),
-                iconTintColor: .primaryOrange, handler: {
-                    print("SET SETTING OPTION VIEWMODEL")
-                }
+            SettingSection(
+                title: "사용설정",
+                options: [
+                    SettingOptionViewModel(
+                        title: "날짜/시간표시",
+                        icon: UIImage(systemName: "calendar"),
+                        iconTintColor: .primaryOrange, handler: {
+                            print("SET SETTING OPTION VIEWMODEL")
+                        }
+                    ),
+                    SettingOptionViewModel(
+                        title: "알림설정",
+                        icon: UIImage(systemName: "bell"),
+                        iconTintColor: .primaryOrange,
+                        handler: {
+                            print("SET SETTING OPTION VIEWMODEL")
+                        }
+                    )
+                ]
             ),
-            SettingOptionViewModel(
-                title: "알림설정",
-                icon: UIImage(systemName: "bell"),
-                iconTintColor: .primaryOrange,
-                handler: {
-                    print("SET SETTING OPTION VIEWMODEL")
-                }
+            SettingSection(
+                title: "애플리케이션",
+                options: [
+                    SettingOptionViewModel(
+                        title: "라이센스",
+                        icon: UIImage(systemName: "text.book.closed"),
+                        iconTintColor: .primaryOrange, handler: {
+                            print("SET SETTING OPTION VIEWMODEL")
+                        }
+                    )
+                ]
             )
         ]
         // 배열 삽입 끝

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  SettingViewModel.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/07.
+//
+
+import UIKit
+
+
+final class SettingViewModel: SettingViewModelProtocol {
+    
+    var settingInfos: [SettingOptionViewModel] = [SettingOptionViewModel]()
+    
+}
+
+// MARK: - Functions
+
+extension SettingViewModel {
+    
+    func configureSettingInfos() {
+        // 배열 삽입 시작
+        settingInfos = [
+            SettingOptionViewModel(
+                title: "날짜/시간표시",
+                icon: UIImage(systemName: "house"),
+                iconTintColor: .primaryOrange, handler: {
+                    print("SET SETTING OPTION VIEWMODEL")
+                }
+            ),
+            SettingOptionViewModel(
+                title: "알림설정",
+                icon: UIImage(systemName: "bell"),
+                iconTintColor: .primaryOrange,
+                handler: {
+                    print("SET SETTING OPTION VIEWMODEL")
+                }
+            )
+        ]
+        // 배열 삽입 끝
+    }
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
@@ -72,5 +72,5 @@ extension SettingViewModel {
 
 struct SettingSection {
     let title: String
-    let options: [SettringOptionType]
+    let options: [SettingOptionType]
 }

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModel.swift
@@ -24,32 +24,43 @@ extension SettingViewModel {
             SettingSection(
                 title: "사용설정",
                 options: [
-                    SettingOptionViewModel(
-                        title: "날짜/시간표시",
-                        icon: UIImage(systemName: "calendar"),
-                        iconTintColor: .primaryOrange, handler: {
-                            print("SET SETTING OPTION VIEWMODEL")
-                        }
+                    .staticCell(
+                        model: SettingOptionViewModel(
+                            title: "날짜/시간표시",
+                            icon: UIImage(systemName: "calendar"),
+                            iconTintColor: .primaryOrange,
+                            handler: {
+                                print("날짜/시간표시 셀 선택")
+                            }
+                        )
                     ),
-                    SettingOptionViewModel(
-                        title: "알림설정",
-                        icon: UIImage(systemName: "bell"),
-                        iconTintColor: .primaryOrange,
-                        handler: {
-                            print("SET SETTING OPTION VIEWMODEL")
-                        }
+                    
+                    .staticCell(
+                        model: SettingOptionViewModel(
+                            title: "알림설정",
+                            icon: UIImage(systemName: "bell"),
+                            iconTintColor: .primaryOrange,
+                            handler: {
+                                print("알림설정 셀 선택")
+                            }
+                        )
                     )
                 ]
             ),
             SettingSection(
+                
                 title: "애플리케이션",
                 options: [
-                    SettingOptionViewModel(
-                        title: "라이센스",
-                        icon: UIImage(systemName: "text.book.closed"),
-                        iconTintColor: .primaryOrange, handler: {
-                            print("SET SETTING OPTION VIEWMODEL")
-                        }
+                    .staticCell(
+                        model: SettingOptionViewModel(
+                            title: "라이센스",
+                            icon: UIImage(systemName: "text.book.closed"),
+                            iconTintColor: .primaryOrange,
+                            handler: {
+                                // TODO: - 라이센스 화면으로 이동 -> delegate 메서드 사용
+                                print("라이센스 셀 선택")
+                            }
+                        )
                     )
                 ]
             )
@@ -57,4 +68,9 @@ extension SettingViewModel {
         // 배열 삽입 끝
     }
     
+}
+
+struct SettingSection {
+    let title: String
+    let options: [SettringOptionType]
 }

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModelProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol SettingViewModelProtocol {
     
-    var settingInfos: [SettingOptionViewModel] { get set }
+    var settingInfos: [SettingSection] { get set }
     
     func configureSettingInfos()
     

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/ViewModel/SettingViewModelProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  SettingViewModelProtocol.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/07.
+//
+
+import Foundation
+
+protocol SettingViewModelProtocol {
+    
+    var settingInfos: [SettingOptionViewModel] { get set }
+    
+    func configureSettingInfos()
+    
+}

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddView.swift
@@ -108,7 +108,7 @@ final class PlanAddView: UIView {
         textView.textColor = .grey3
         textView.font = .systemFont(ofSize: Metric.textViewFontSize, weight: .regular)
         textView.backgroundColor = .grey1
-        textView.contentInset = textViewInset
+//        textView.contentInset = textViewInset 에러발생으로 주석처리
         return textView
     }()
     


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 기본적인 설정 뷰 UI를 작성하였습니다.
- 설정화면에 있는 목록은 다음 세가지 입니다.
   1. 날짜/시간 표시
   2. 알림설정
   3. 라이센스

## 리뷰노트
> 고민, 과정, 궁금한점
- 기존처럼 UICollectionView, Compositional Layout, DiffableDataSource를 사용해야할까?
   - 설정화면 셀에 나오는 데이터들이 변하지 않기 때문에 DiffableDataSource를 사용하지 않았습니다.
   - Compositional Layout을 작성하게 되었을 때 불필요한 코드들이 많아져 사용하지 않았습니다.
- 설정화면의 셀을 터치했을 때는 크게 두가지 동작을 할것이라 생각했습니다.
   - 셀을 터치했을때 해당 내용을 설정할 수 있는 다음 뷰컨트롤러로 이동하는 셀
   - 셀 내부에 `UISwitch`가 오른쪽에 존재하는 셀
   두가지를 구분하기 위해서 Cell의 Type을 열거형으로 정의하였습니다.
   ```swift
   enum SettingOptionType {
       case staticCell(model: SettingOptionViewModel)
       case switchCell(model: SettingOptionViewModel)
   }
   ```
   각 케이스가 설정 셀을 나타낼 정보를 담은 `SettingOptionViewModel`을 연관값으로 가지고 있습니다.

## 스크린샷
<img width="300" src="https://user-images.githubusercontent.com/76734067/206171639-1024f9ec-d7c2-4414-bbbb-01150d6c935d.png">
