### PR TITLE
[리팩토링] 다이어리 상세 조회 리팩토링

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -84,7 +84,7 @@
 		B5D64E78292E4B9A00E1CC81 /* DetailImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */; };
 		B5D64E7A292E684000E1CC81 /* DetailImageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D64E79292E684000E1CC81 /* DetailImageCellViewModel.swift */; };
 		B5DE4D4029271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DE4D3F29271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift */; };
-		B5DEDE3829409CD400AD2515 /* DetailImageSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */; };
+		B5DEDE3829409CD400AD2515 /* ImageSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DEDE3729409CD400AD2515 /* ImageSliderView.swift */; };
 		BB02B090292F294C00FE11DA /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B08F292F294C00FE11DA /* DiaryListViewController.swift */; };
 		BB02B092292F295800FE11DA /* DiaryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B091292F295800FE11DA /* DiaryListViewModel.swift */; };
 		BB02B094292F29E000FE11DA /* DiaryListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */; };
@@ -278,7 +278,7 @@
 		B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageCell.swift; sourceTree = "<group>"; };
 		B5D64E79292E684000E1CC81 /* DetailImageCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageCellViewModel.swift; sourceTree = "<group>"; };
 		B5DE4D3F29271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewControllerDelegate.swift; sourceTree = "<group>"; };
-		B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageSliderView.swift; sourceTree = "<group>"; };
+		B5DEDE3729409CD400AD2515 /* ImageSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSliderView.swift; sourceTree = "<group>"; };
 		BB02B08F292F294C00FE11DA /* DiaryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewController.swift; sourceTree = "<group>"; };
 		BB02B091292F295800FE11DA /* DiaryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModel.swift; sourceTree = "<group>"; };
 		BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -466,6 +466,7 @@
 		A4CC04B0292261E000BB678B /* DiaryScene */ = {
 			isa = PBXGroup;
 			children = (
+				B5DEDE402940D6BB00AD2515 /* ImageSlider */,
 				EE3FB854293751850024AEE1 /* DiaryPhotoDetail */,
 				BB02B08C292F292900FE11DA /* DiaryList */,
 				B5D64E64292DFC9900E1CC81 /* DiaryDetail */,
@@ -705,7 +706,6 @@
 			isa = PBXGroup;
 			children = (
 				B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */,
-				B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */,
 				B5D64E68292DFEF000E1CC81 /* DiaryDetailView.swift */,
 				B5D64E66292DFED500E1CC81 /* DiaryDetailViewController.swift */,
 			);
@@ -729,6 +729,22 @@
 				B5D64E75292E3B6C00E1CC81 /* DiaryDetailLocalRepository.swift */,
 			);
 			path = DiaryDetail;
+			sourceTree = "<group>";
+		};
+		B5DEDE402940D6BB00AD2515 /* ImageSlider */ = {
+			isa = PBXGroup;
+			children = (
+				B5DEDE412940D6CA00AD2515 /* View */,
+			);
+			path = ImageSlider;
+			sourceTree = "<group>";
+		};
+		B5DEDE412940D6CA00AD2515 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				B5DEDE3729409CD400AD2515 /* ImageSliderView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		BB02B08C292F292900FE11DA /* DiaryList */ = {
@@ -1578,7 +1594,7 @@
 				A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */,
 				BB6BE55B2936020300857D25 /* FaceDetectController+CollectionView.swift in Sources */,
 				BB6BE5572935E68E00857D25 /* FaceDetectViewModel.swift in Sources */,
-				B5DEDE3829409CD400AD2515 /* DetailImageSliderView.swift in Sources */,
+				B5DEDE3829409CD400AD2515 /* ImageSliderView.swift in Sources */,
 				EEDB753629260E360069A7F5 /* PlanAddViewProtocol.swift in Sources */,
 				B5D64E63292DF06400E1CC81 /* DiaryAddView.swift in Sources */,
 				A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */,

--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		B5D64E78292E4B9A00E1CC81 /* DetailImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */; };
 		B5D64E7A292E684000E1CC81 /* DetailImageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D64E79292E684000E1CC81 /* DetailImageCellViewModel.swift */; };
 		B5DE4D4029271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DE4D3F29271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift */; };
+		B5DEDE3829409CD400AD2515 /* DetailImageSliderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */; };
 		BB02B090292F294C00FE11DA /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B08F292F294C00FE11DA /* DiaryListViewController.swift */; };
 		BB02B092292F295800FE11DA /* DiaryListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B091292F295800FE11DA /* DiaryListViewModel.swift */; };
 		BB02B094292F29E000FE11DA /* DiaryListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */; };
@@ -277,6 +278,7 @@
 		B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageCell.swift; sourceTree = "<group>"; };
 		B5D64E79292E684000E1CC81 /* DetailImageCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageCellViewModel.swift; sourceTree = "<group>"; };
 		B5DE4D3F29271EA400D13F98 /* SearchingLocationViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationViewControllerDelegate.swift; sourceTree = "<group>"; };
+		B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailImageSliderView.swift; sourceTree = "<group>"; };
 		BB02B08F292F294C00FE11DA /* DiaryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewController.swift; sourceTree = "<group>"; };
 		BB02B091292F295800FE11DA /* DiaryListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModel.swift; sourceTree = "<group>"; };
 		BB02B093292F29E000FE11DA /* DiaryListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewModelProtocol.swift; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 			isa = PBXGroup;
 			children = (
 				B5D64E77292E4B9A00E1CC81 /* DetailImageCell.swift */,
+				B5DEDE3729409CD400AD2515 /* DetailImageSliderView.swift */,
 				B5D64E68292DFEF000E1CC81 /* DiaryDetailView.swift */,
 				B5D64E66292DFED500E1CC81 /* DiaryDetailViewController.swift */,
 			);
@@ -1575,6 +1578,7 @@
 				A48E9948292515020029D57D /* UIViewController+PresentAlert.swift in Sources */,
 				BB6BE55B2936020300857D25 /* FaceDetectController+CollectionView.swift in Sources */,
 				BB6BE5572935E68E00857D25 /* FaceDetectViewModel.swift in Sources */,
+				B5DEDE3829409CD400AD2515 /* DetailImageSliderView.swift in Sources */,
 				EEDB753629260E360069A7F5 /* PlanAddViewProtocol.swift in Sources */,
 				B5D64E63292DF06400E1CC81 /* DiaryAddView.swift in Sources */,
 				A4CC04E02923738500BB678B /* PlanLocalRepository.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddView.swift
@@ -61,42 +61,7 @@ final class DiaryAddView: UIView {
         return button
     }()
 
-    let pageControl: UIPageControl = {
-        let control = UIPageControl()
-        control.pageIndicatorTintColor = .grey1
-        control.currentPageIndicatorTintColor = .primaryOrange
-
-        return control
-    }()
-
-    private(set) lazy var imageSlider: UICollectionView = {
-        let itemSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(Metric.one),
-            heightDimension: .fractionalHeight(Metric.one)
-        )
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(Metric.one),
-            heightDimension: .fractionalHeight(Metric.one)
-        )
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
-        let section = NSCollectionLayoutSection(group: group)
-        section.orthogonalScrollingBehavior = .paging
-        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, _, _ in
-            self?.pageControl.currentPage = visibleItems.last?.indexPath.row ?? .zero
-        }
-
-        let layout = UICollectionViewCompositionalLayout(section: section)
-
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.showsVerticalScrollIndicator = false
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.allowsSelection = false
-
-        return collectionView
-    }()
+    private(set) lazy var imageSlider = ImageSliderView()
 
     private let divider: UIView = {
         let view = UIView()
@@ -163,7 +128,7 @@ final class DiaryAddView: UIView {
         scrollView.addSubview(contentStack)
         let contentStackSubviews = [
             travelTextField, placeSearchButton,
-            imageSlider, pageControl,
+            imageSlider,
             titleTextField, divider, contentTextView
         ]
         contentStack.addArrangedSubviews(contentStackSubviews)

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/View/DiaryAddViewController.swift
@@ -122,7 +122,7 @@ final class DiaryAddViewController: UIViewController {
                     cell.image = image
                 }
         }
-        let collectionView = self.rootView.imageSlider
+        let collectionView = self.rootView.imageSlider.slider
 
         let dataSource = DataSource(
             collectionView: collectionView
@@ -227,7 +227,7 @@ extension DiaryAddViewController: DiaryAddViewModelDelegate {
     }
 
     func diaryAddViewModelDidUpdateSelectedImageIDs(_ identifiers: [ImageID]) {
-        rootView.pageControl.numberOfPages = identifiers.count
+        rootView.imageSlider.setupNumberOfPages(identifiers.count)
         applySnapshot(usingIDs: identifiers)
     }
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageCell.swift
@@ -13,6 +13,7 @@ final class DetailImageCell: UICollectionViewCell {
     private let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         
         return imageView
     }()

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageSliderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageSliderView.swift
@@ -1,0 +1,139 @@
+//
+//  DetailImageSliderView.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/12/07.
+//
+
+import UIKit
+
+final class DetailImageSliderView: UIView {
+    
+    // MARK: - UI Properties
+    
+    /// 이미지 슬라이더 뷰.
+    private(set) lazy var slider: UICollectionView = {
+        let layout = configureCompositionalLayout()
+        
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .white
+        collectionView.isPagingEnabled = true
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.showsVerticalScrollIndicator = false
+        
+        return collectionView
+    }()
+    
+    /// 페이지 컨트롤
+    private let pageControl: UIPageControl = {
+        let control = UIPageControl()
+        control.pageIndicatorTintColor = .grey1
+        control.currentPageIndicatorTintColor = .primaryOrange
+        control.isUserInteractionEnabled = false
+        control.hidesForSinglePage = true
+        
+        return control
+    }()
+    
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        
+        return stack
+    }()
+    
+    // MARK: - Properties
+    
+    weak var delegate: UICollectionViewDelegate? {
+        get { slider.delegate }
+        set { slider.delegate = newValue }
+    }
+    
+    weak var dataSource: UICollectionViewDataSource? {
+        get { slider.dataSource }
+        set { slider.dataSource = newValue }
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureViews()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Configure Function
+    
+    private func configureViews() {
+        configureSubviews()
+        configureConstraints()
+    }
+    
+    private func configureSubviews() {
+        contentStack.addArrangedSubviews(slider, pageControl)
+        addSubview(contentStack)
+    }
+    
+    private func configureConstraints() {
+        contentStack.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+    
+    // MARK: - Layout Functions
+    
+    /// 이미지 슬라이더의 레이아웃을 생성한다.
+    private func configureCompositionalLayout() -> UICollectionViewCompositionalLayout {
+        let layoutSize = configureImageSliderLayoutSize()
+        let subitem = NSCollectionLayoutItem(layoutSize: layoutSize)
+        
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: layoutSize,
+            subitems: [subitem]
+        )
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .paging
+        section.visibleItemsInvalidationHandler = { [weak self] _, offset, _ in
+            guard let self = self else { return }
+            let collectionViewWidth = self.slider.bounds.width
+            let currentPage = Int(offset.x / collectionViewWidth)
+            self.pageControl.currentPage = currentPage
+        }
+        
+        let layout = UICollectionViewCompositionalLayout(section: section)
+
+        return layout
+    }
+    
+    /// 이미지 슬라이더 레이아웃의 크기를 지정한다.
+    private func configureImageSliderLayoutSize() -> NSCollectionLayoutSize {
+        let layoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(Metric.one),
+            heightDimension: .fractionalWidth(Metric.one)
+        )
+        return layoutSize
+    }
+    
+    // MARK: - Setup Functions
+    
+    func setupNumberOfPages(_ count: Int) {
+        pageControl.numberOfPages = count
+    }
+    
+    func setupCurrentPage(_ pageIndex: Int) {
+        pageControl.currentPage = pageIndex
+    }
+    
+    func setupImageSliderShowing(with isHidden: Bool) {
+        slider.isHidden = isHidden
+    }
+}
+
+extension DetailImageSliderView {
+    enum Metric {
+        static let one: CGFloat = 1
+    }
+}

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageSliderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DetailImageSliderView.swift
@@ -20,6 +20,7 @@ final class DetailImageSliderView: UIView {
         collectionView.isPagingEnabled = true
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
+        collectionView.allowsSelection = false
         
         return collectionView
     }()
@@ -96,11 +97,8 @@ final class DetailImageSliderView: UIView {
         
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .paging
-        section.visibleItemsInvalidationHandler = { [weak self] _, offset, _ in
-            guard let self = self else { return }
-            let collectionViewWidth = self.slider.bounds.width
-            let currentPage = Int(offset.x / collectionViewWidth)
-            self.pageControl.currentPage = currentPage
+        section.visibleItemsInvalidationHandler = { [weak self] visibleItems, _, _ in
+            self?.setupCurrentPage(visibleItems.last?.indexPath.row ?? .zero)
         }
         
         let layout = UICollectionViewCompositionalLayout(section: section)

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -15,7 +15,6 @@ final class DiaryDetailView: UIView {
     /// 다이어리 조회 중 나타나는 액티비티 인디케이터 뷰
     private let activityIndicatorView: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView()
-        indicator.hidesWhenStopped = true
         indicator.startAnimating()
         
         return indicator

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -22,7 +22,7 @@ final class DiaryDetailView: UIView {
     }()
     
     /// 이미지 슬라이더 뷰.
-    lazy var imageSlider = DetailImageSliderView()
+    lazy var imageSlider = ImageSliderView()
     
     /// 내용 레이블
     private let contentLabel: UILabel = {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -12,11 +12,21 @@ import SnapKit
 final class DiaryDetailView: UIView {
     // MARK: - UI Properties
     
+    /// 다이어리 조회 중 나타나는 액티비티 인디케이터 뷰
+    private let activityIndicatorView: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView()
+        indicator.hidesWhenStopped = true
+        indicator.startAnimating()
+        
+        return indicator
+    }()
+    
     /// 이미지 슬라이더 뷰.
     lazy var imageSlider: UICollectionView = {
         let layout = configureCompositionalLayout()
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .white
         collectionView.isPagingEnabled = true
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.showsVerticalScrollIndicator = false
@@ -118,6 +128,7 @@ final class DiaryDetailView: UIView {
         
         let dateFormatter = Date.yearMonthDayTimeDateFormatter
         dateLabel.text = dateFormatter.string(from: diary.date ?? Date())
+        activityIndicatorView.stopAnimating()
     }
     
     func setupNumberOfPages(_ count: Int) {
@@ -146,7 +157,7 @@ final class DiaryDetailView: UIView {
         contentStack.addArrangedSubviews(imageStack, contentLabel, infoStack)
         
         scrollView.addSubview(contentStack)
-        addSubview(scrollView)
+        addSubviews(scrollView, activityIndicatorView)
     }
     
     private func configureConstraint() {
@@ -160,6 +171,7 @@ final class DiaryDetailView: UIView {
         imageStack.snp.makeConstraints { $0.horizontalEdges.equalToSuperview() }
         contentStack.snp.makeConstraints { $0.edges.width.equalToSuperview() }
         scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        activityIndicatorView.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
     
     // MARK: - Collection View

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -22,36 +22,7 @@ final class DiaryDetailView: UIView {
     }()
     
     /// 이미지 슬라이더 뷰.
-    lazy var imageSlider: UICollectionView = {
-        let layout = configureCompositionalLayout()
-        
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
-        collectionView.backgroundColor = .white
-        collectionView.isPagingEnabled = true
-        collectionView.showsHorizontalScrollIndicator = false
-        collectionView.showsVerticalScrollIndicator = false
-        
-        return collectionView
-    }()
-    
-    /// 페이지 컨트롤
-    private let pageControl: UIPageControl = {
-        let pageControl = UIPageControl()
-        pageControl.pageIndicatorTintColor = .grey2
-        pageControl.currentPageIndicatorTintColor = .grey4
-        pageControl.isUserInteractionEnabled = false
-        pageControl.hidesForSinglePage = true
-        
-        return pageControl
-    }()
-    
-    /// 이미지 슬라이더, 페이지 컨트롤을 포함하는 스택 뷰
-    private let imageStack: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .vertical
-        
-        return stackView
-    }()
+    lazy var imageSlider = DetailImageSliderView()
     
     /// 내용 레이블
     private let contentLabel: UILabel = {
@@ -132,11 +103,11 @@ final class DiaryDetailView: UIView {
     }
     
     func setupNumberOfPages(_ count: Int) {
-        pageControl.numberOfPages = count
+        imageSlider.setupNumberOfPages(count)
     }
     
     func setupCurrentPage(_ pageIndex: Int) {
-        pageControl.currentPage = pageIndex
+        imageSlider.setupCurrentPage(pageIndex)
     }
     
     func setupImageSliderShowing(with isHidden: Bool) {
@@ -151,10 +122,8 @@ final class DiaryDetailView: UIView {
     }
     
     private func configureSubviews() {
-        imageStack.addArrangedSubviews(imageSlider, pageControl)
         infoStack.addArrangedSubviews(locationLabel, dateLabel)
-        
-        contentStack.addArrangedSubviews(imageStack, contentLabel, infoStack)
+        contentStack.addArrangedSubviews(imageSlider, contentLabel, infoStack)
         
         scrollView.addSubview(contentStack)
         addSubviews(scrollView, activityIndicatorView)
@@ -168,45 +137,10 @@ final class DiaryDetailView: UIView {
             }
         }
         
-        imageStack.snp.makeConstraints { $0.horizontalEdges.equalToSuperview() }
+        imageSlider.snp.makeConstraints { $0.horizontalEdges.equalToSuperview() }
         contentStack.snp.makeConstraints { $0.edges.width.equalToSuperview() }
         scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
         activityIndicatorView.snp.makeConstraints { $0.edges.equalToSuperview() }
-    }
-    
-    // MARK: - Collection View
-    
-    /// 이미지 슬라이더의 레이아웃을 생성한다.
-    private func configureCompositionalLayout() -> UICollectionViewCompositionalLayout {
-        let layoutSize = configureImageSliderLayoutSize()
-        let subitem = NSCollectionLayoutItem(layoutSize: layoutSize)
-        
-        let group = NSCollectionLayoutGroup.horizontal(
-            layoutSize: layoutSize,
-            subitems: [subitem]
-        )
-        
-        let section = NSCollectionLayoutSection(group: group)
-        section.orthogonalScrollingBehavior = .paging
-        section.visibleItemsInvalidationHandler = { [weak self] _, offset, _ in
-            guard let self = self else { return }
-            let collectionViewWidth = self.imageSlider.bounds.width
-            let currentPage = Int(offset.x / collectionViewWidth)
-            self.pageControl.currentPage = currentPage
-        }
-        
-        let layout = UICollectionViewCompositionalLayout(section: section)
-
-        return layout
-    }
-    
-    /// 이미지 슬라이더 레이아웃의 크기를 지정한다.
-    private func configureImageSliderLayoutSize() -> NSCollectionLayoutSize {
-        let layoutSize = NSCollectionLayoutSize(
-            widthDimension: .fractionalWidth(1),
-            heightDimension: .fractionalWidth(1)
-        )
-        return layoutSize
     }
     
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -111,7 +111,7 @@ final class DiaryDetailViewController: UIViewController {
         }
         
         imageSliderDataSource = DataSource(
-            collectionView: rootView.imageSlider
+            collectionView: rootView.imageSlider.slider
         ) { collectionView, indexPath, itemIdentifier in
             let cell = collectionView.dequeueConfiguredReusableCell(
                 using: cellRegistration,

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -172,7 +172,6 @@ extension DiaryDetailViewController {
 
 extension DiaryDetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // TODO: 이미지를 선택했을 때 이미지 상세 화면으로 이동하도록 구현
         guard let imageSliderDataSource,
               let item = imageSliderDataSource.itemIdentifier(for: indexPath) else {
             return

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
@@ -30,7 +30,6 @@ final class DiaryDetailViewModel {
     
     // MARK: - Init
     
-    // TODO: 이니셜라이징할 때 Result를 넘겨주는 방법..???을 모르겠어서 그냥 fail뜨면 nil처리되도록..
     init?(id: UUID) {
         let result = repository.getDiaryDetail(with: id)
         switch result {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/ImageSlider/View/ImageSliderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/ImageSlider/View/ImageSliderView.swift
@@ -1,5 +1,5 @@
 //
-//  DetailImageSliderView.swift
+//  ImageSliderView.swift
 //  Doesaegim
 //
 //  Created by 서보경 on 2022/12/07.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DetailImageSliderView: UIView {
+final class ImageSliderView: UIView {
     
     // MARK: - UI Properties
     
@@ -130,7 +130,7 @@ final class DetailImageSliderView: UIView {
     }
 }
 
-extension DetailImageSliderView {
+extension ImageSliderView {
     enum Metric {
         static let one: CGFloat = 1
     }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 다이어리 상세 정보가 로딩되는 동안 ActivityIndicator가 띄워지도록 구현했습니다.
- 다이어리 상세 정보가 로딩되는 동안 보여지는 컬렉션뷰의 배경색을 수정했습니다.
- 이미지 슬라이드 시 이전 페이지의 이미지가 살짝 넘어가 보이는 현상을 수정했습니다.
- 이미지 슬라이드 컬렉션 뷰와 페이지 컨트롤을 별도의 클래스 `ImageSliderView` 로 묶어 분리했습니다.

## 리뷰노트
> 고민, 과정, 궁금한점
- `DiaryDetailView`에서 컬렉션뷰가 차지하는 비중이 매우 커서 컬렉션뷰와 페이지 컨트롤을 묶어 클래스로 관리하면 좋겠다! 라는 생각이 들었고, 결국 `ImageSliderView`를 별도로 분리했습니다.
- 이렇게 `ImageSliderView`를 구현하고 나니 `DiaryAddView`에서 사용하는 이미지 슬라이더와도 상당히 유사한 부분이 많아서 공통적으로 사용할 수 있도록 컬렉션뷰 셀도 함께 구현하려고 했지만... 우선은 컬렉션뷰만 구현하게 되었습니다.
  - **다이어리 조회 화면**의 경우 진입 시 파일 시스템 내 이미지 경로 배열을 통해 이미지 데이터를 모두 받아와 화면에는 받아져있는 데이터들을 표시만 하는 방식으로 구현되어 있습니다.
  - **다이어리 추가 화면**의 경우 각 셀마다 ImageID와 ItemProvider를 통해 이미지를 받아오는데, 이때 이미지를 완전히 받아오기 전까지는 Progress를 표시하는 방식으로 이해했습니다.
  - 이처럼 두 화면에서 이미지를 표시하는 방식에 차이가 있어 두 컬렉션뷰 셀 `DetailImageCell`, `ProgressiveImageCollectionViewCell` 을 공통으로 묶을 수 있는 지에 대해서는 조금 더 고민해볼 예정입니다.
  - ~~공통으로 사용하게 된다면 DetailImageSliderView 대신 쓰기 좋을 이름 추천 받습니다..~~ -> `ImageSliderView`로 변경했읍니다..^^

## 스크린샷
첫번째 스크린샷은 ActivityIndicator와 배경색, `clipsToBounds` 적용 전의 모습이고, 두번째 스크린샷은 적용 후의 모습입니다!

https://user-images.githubusercontent.com/50136980/206183587-e9d30e79-2a69-415d-98ad-3d2c01b41132.mp4


https://user-images.githubusercontent.com/50136980/206183646-0ac65565-8ede-4d36-a248-62d35c7e3ea4.mp4

