### PR TITLE
[리팩토링] 장소 검색 Repository 구현 및 적용

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		B53763D5292B61A40073BF46 /* CustomChartItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763D4292B61A40073BF46 /* CustomChartItem.swift */; };
 		B53763E3292B99B80073BF46 /* PieceShapeLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */; };
 		B53763E8292BA0760073BF46 /* PieceTextLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53763E7292BA0760073BF46 /* PieceTextLayer.swift */; };
+		B5683DF5294188DB00FF3E38 /* SearchingLocationRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5683DF4294188DB00FF3E38 /* SearchingLocationRepository.swift */; };
+		B5683DF929418A2200FF3E38 /* SearchingLocationRemoteRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5683DF829418A2200FF3E38 /* SearchingLocationRemoteRepository.swift */; };
 		B5716134293CE56E002FDC35 /* CustomChartType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5716133293CE56E002FDC35 /* CustomChartType.swift */; };
 		B57D96262922301E00B510B8 /* TravelDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D96252922301E00B510B8 /* TravelDTO.swift */; };
 		B57D9628292230CA00B510B8 /* PlanDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57D9627292230CA00B510B8 /* PlanDTO.swift */; };
@@ -259,6 +261,8 @@
 		B53763D4292B61A40073BF46 /* CustomChartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChartItem.swift; sourceTree = "<group>"; };
 		B53763E2292B99B80073BF46 /* PieceShapeLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceShapeLayer.swift; sourceTree = "<group>"; };
 		B53763E7292BA0760073BF46 /* PieceTextLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceTextLayer.swift; sourceTree = "<group>"; };
+		B5683DF4294188DB00FF3E38 /* SearchingLocationRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationRepository.swift; sourceTree = "<group>"; };
+		B5683DF829418A2200FF3E38 /* SearchingLocationRemoteRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchingLocationRemoteRepository.swift; sourceTree = "<group>"; };
 		B5716133293CE56E002FDC35 /* CustomChartType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomChartType.swift; sourceTree = "<group>"; };
 		B57D96252922301E00B510B8 /* TravelDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelDTO.swift; sourceTree = "<group>"; };
 		B57D9627292230CA00B510B8 /* PlanDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDTO.swift; sourceTree = "<group>"; };
@@ -563,6 +567,7 @@
 		A4CC04DB292351E700BB678B /* TravelScene */ = {
 			isa = PBXGroup;
 			children = (
+				B5683DF3294188C700FF3E38 /* SearchingLocation */,
 				EE97A8B0294053C000BB8390 /* PlanAdd */,
 				EE5D50F1293DD402006ECE87 /* TravelAdd */,
 				A4CC04DC292351F800BB678B /* PlanList */,
@@ -617,6 +622,15 @@
 				B53763E7292BA0760073BF46 /* PieceTextLayer.swift */,
 			);
 			path = PieChart;
+			sourceTree = "<group>";
+		};
+		B5683DF3294188C700FF3E38 /* SearchingLocation */ = {
+			isa = PBXGroup;
+			children = (
+				B5683DF4294188DB00FF3E38 /* SearchingLocationRepository.swift */,
+				B5683DF829418A2200FF3E38 /* SearchingLocationRemoteRepository.swift */,
+			);
+			path = SearchingLocation;
 			sourceTree = "<group>";
 		};
 		B57D962229222FC500B510B8 /* Data */ = {
@@ -1595,6 +1609,7 @@
 				BB288FC8292E167900065D04 /* DiaryCalloutView.swift in Sources */,
 				BBDB2E9429262BB300752924 /* ExpenseCollectionHeaderView.swift in Sources */,
 				B5D64E61292DF06400E1CC81 /* PlaceSearchButton.swift in Sources */,
+				B5683DF5294188DB00FF3E38 /* SearchingLocationRepository.swift in Sources */,
 				EE3FB85C29386B850024AEE1 /* AddViewSubtitleLabel.swift in Sources */,
 				BBB31A372925F5E400C9E3A9 /* TravelListCell.swift in Sources */,
 				B5D64E69292DFEF000E1CC81 /* DiaryDetailView.swift in Sources */,
@@ -1702,6 +1717,7 @@
 				EEDB752F2925E8DD0069A7F5 /* CalendarViewController.swift in Sources */,
 				A4B82DD4293D7F2100347B71 /* Array+SafeIndex.swift in Sources */,
 				B5D64E67292DFED500E1CC81 /* DiaryDetailViewController.swift in Sources */,
+				B5683DF929418A2200FF3E38 /* SearchingLocationRemoteRepository.swift in Sources */,
 				EE3FB860293894810024AEE1 /* AddViewTextField.swift in Sources */,
 				B5D64E6C292E22A400E1CC81 /* DiaryDetailViewModel.swift in Sources */,
 				B5B497DC29379FC3009AE4AC /* BarTextLayer.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationView.swift
@@ -13,6 +13,13 @@ final class SearchingLocationView: UIView {
     
     // MARK: - UI Properties
     
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView()
+        indicator.backgroundColor = .grey2?.withAlphaComponent(Metric.IndicatorBackgroundAlpha)
+        
+        return indicator
+    }()
+    
     /// 검색 결과를 표시하는 컬렉션 뷰
     lazy var searchResultCollectionView: EmptyLabeledCollectionView = {
         var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
@@ -43,7 +50,7 @@ final class SearchingLocationView: UIView {
     }
     
     
-    // MARK: - Functions
+    // MARK: - Configure Functions
     
     private func configureViews() {
         backgroundColor = .white
@@ -52,17 +59,32 @@ final class SearchingLocationView: UIView {
     }
     
     private func configureSubviews() {
-        addSubview(searchResultCollectionView)
+        addSubviews(searchResultCollectionView, activityIndicator)
     }
     
     private func configureConstraints() {
         searchResultCollectionView.snp.makeConstraints {
             $0.edges.equalTo(safeAreaLayoutGuide)
         }
+        activityIndicator.snp.makeConstraints { $0.edges.equalToSuperview() }
+    }
+    
+    // MARK: - Activity Indicator Functions
+    
+    func startAnimating() {
+        activityIndicator.startAnimating()
+    }
+    
+    func stopAnimating() {
+        activityIndicator.stopAnimating()
     }
 }
 
 fileprivate extension SearchingLocationView {
+    enum Metric {
+        static let IndicatorBackgroundAlpha: CGFloat = 0.7
+    }
+    
     enum StringLiteral {
         static let emptyLabelText = "장소 검색 결과가 없습니다."
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/View/SearchingLocationViewController.swift
@@ -109,15 +109,6 @@ final class SearchingLocationViewController: UIViewController {
     }
 }
 
-// MARK: - Namespaces
-
-extension SearchingLocationViewController {
-    enum StringLiteral {
-        static let title = "장소 검색"
-        static let searchBarPlaceholder = "장소명을 입력해주세요."
-    }
-}
-
 // MARK: - SearchingLocationViewController.Section
 
 extension SearchingLocationViewController {
@@ -160,11 +151,33 @@ extension SearchingLocationViewController: UICollectionViewDelegate {
 // MARK: - SearchingLocationViewModelDelegate
 
 extension SearchingLocationViewController: SearchingLocationViewModelDelegate {
+    
+    func searchLocationWillStart() {
+        rootView.startAnimating()
+    }
+    
     func searchLocaitonResultDidChange() {
         rootView.searchResultCollectionView.isEmpty = viewModel.searchResultCellViewModels.isEmpty
+        rootView.stopAnimating()
     }
     
     func searchLocationSnapshotDidRefresh() {
         configureSnapshot()
+    }
+    
+    func searchLocationErrorOccurred() {
+        presentErrorAlert(title: StringLiteral.responseErrorTitle)
+    }
+}
+
+
+// MARK: - Namespaces
+
+extension SearchingLocationViewController {
+    enum StringLiteral {
+        static let title = "장소 검색"
+        static let searchBarPlaceholder = "장소명을 입력해주세요."
+        
+        static let responseErrorTitle = "검색 결과 요청에 실패했습니다."
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -34,18 +34,15 @@ final class SearchingLocationViewModel {
     /// - Parameter keyword: 입력된 키워드
     func fetchSearchResults(with keyword: String) {
         delegate?.searchLocationWillStart()
-        Task {
-            let result = await repository.search(with: keyword)
-            
-            DispatchQueue.main.async { [weak self] in
-                switch result {
-                case .success(let cellViewModels):
-                    self?.searchResultCellViewModels = cellViewModels
-                case .failure(let error):
-                    self?.searchResultCellViewModels = []
-                    self?.delegate?.searchLocationErrorOccurred()
-                    print(error.localizedDescription)
-                }
+
+        repository.search(with: keyword) { [weak self] result in
+            switch result {
+            case .success(let cellViewModels):
+                self?.searchResultCellViewModels = cellViewModels
+            case .failure(let error):
+                self?.searchResultCellViewModels = []
+                self?.delegate?.searchLocationErrorOccurred()
+                print(error.localizedDescription)
             }
         }
     }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModel.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
-import MapKit
 
 final class SearchingLocationViewModel {
     
     // MARK: - Properties
+    
+    private let repository: SearchingLocationRepository
     
     weak var delegate: SearchingLocationViewModelDelegate?
     
@@ -21,35 +22,31 @@ final class SearchingLocationViewModel {
         }
     }
     
+    // MARK: - Init
+    
+    init() {
+        repository = SearchingLocationRemoteRepository()
+    }
+    
     // MARK: - Functions
     
     /// 키워드를 통해 장소를 검색하고, 검색 결과값을 `searchResultCellViewModels`에 저장한다.
     /// - Parameter keyword: 입력된 키워드
     func fetchSearchResults(with keyword: String) {
-        let request = MKLocalSearch.Request()
-        request.naturalLanguageQuery = keyword
-        request.region = MKCoordinateRegion(MKMapRect.world)
-        
-        let search = MKLocalSearch(request: request)
-        search.start { response, error in
-            guard let response = response, error == nil
-            else {
-                // TODO: 에러 처리 필요
-                self.searchResultCellViewModels = []
-                return
+        delegate?.searchLocationWillStart()
+        Task {
+            let result = await repository.search(with: keyword)
+            
+            DispatchQueue.main.async { [weak self] in
+                switch result {
+                case .success(let cellViewModels):
+                    self?.searchResultCellViewModels = cellViewModels
+                case .failure(let error):
+                    self?.searchResultCellViewModels = []
+                    self?.delegate?.searchLocationErrorOccurred()
+                    print(error.localizedDescription)
+                }
             }
-            
-            let cellViewModels = response.mapItems.map({
-                let placemark = $0.placemark
-                return SearchResultCellViewModel(
-                    name: placemark.name ?? "",
-                    address: (placemark.locality ?? "") + " " + (placemark.thoroughfare ?? ""),
-                    latitude: placemark.coordinate.latitude,
-                    longitude: placemark.coordinate.longitude
-                )
-            })
-            
-            self.searchResultCellViewModels = cellViewModels
         }
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/SearchingLocation/ViewModel/SearchingLocationViewModelDelegate.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 protocol SearchingLocationViewModelDelegate: AnyObject {
+    func searchLocationWillStart()
     func searchLocaitonResultDidChange()
     func searchLocationSnapshotDidRefresh()
+    func searchLocationErrorOccurred()
 }

--- a/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRemoteRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRemoteRepository.swift
@@ -1,0 +1,36 @@
+//
+//  SearchingLocationRemoteRepository.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/12/08.
+//
+
+import Foundation
+import MapKit
+
+final class SearchingLocationRemoteRepository: SearchingLocationRepository {
+    private let request = MKLocalSearch.Request()
+    
+    func search(with keyword: String) async -> Result<[SearchResultCellViewModel], NetworkError> {
+        request.naturalLanguageQuery = keyword
+        request.region = MKCoordinateRegion(MKMapRect.world)
+        
+        let search = MKLocalSearch(request: request)
+        do {
+            let response = try await search.start()
+            let cellViewModels = response.mapItems.map({
+                let placemark = $0.placemark
+                return SearchResultCellViewModel(
+                    name: placemark.name ?? "",
+                    address: (placemark.locality ?? "") + " " + (placemark.thoroughfare ?? ""),
+                    latitude: placemark.coordinate.latitude,
+                    longitude: placemark.coordinate.longitude
+                )
+            })
+            
+            return .success(cellViewModels)
+        } catch {
+            return .failure(NetworkError.responseError)
+        }
+    }
+}

--- a/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRepository.swift
@@ -1,0 +1,12 @@
+//
+//  SearchingLocationRepository.swift
+//  Doesaegim
+//
+//  Created by 서보경 on 2022/12/08.
+//
+
+import Foundation
+
+protocol SearchingLocationRepository {
+    func search(with keyworkd: String) async -> Result<[SearchResultCellViewModel], NetworkError>
+}

--- a/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRepository.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 protocol SearchingLocationRepository {
-    func search(with keyworkd: String) async -> Result<[SearchResultCellViewModel], NetworkError>
+    func search(
+        with keyword: String,
+        completion: @escaping ((Result<[SearchResultCellViewModel], NetworkError>) -> Void)
+    )
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 기존에 SearchingLocationViewModel에 방생해두었던 MKLocalSearch 로직을 `SearchingLocationRemoteRepository`로 별도 분리했습니다~!
- 검색 결과를 불러오는 데 실패했을 경우 Alert를 띄워주도록 수정했습니다.
- 검색하는 동안 Activity Indicator가 표시되도록 수정했습니다.

## 리뷰노트
> 고민, 과정, 궁금한점
- 장소 검색 로직을 repository로 분리하는 과정에서 async/await을 도입하려고 했지만 오히려 코드 뎁스가 깊어지기도 하고, MKLocalSearch.start 메서드의 completionHandler에 내장되어 있는 메인스레드를 포기하는 것이 아쉬워서 그대로 completion을 통해 검색 처리 결과를 보내도록 했습니다.

## 스크린샷

https://user-images.githubusercontent.com/50136980/206369325-9aa62e98-7e3a-444b-835f-be062b6b1398.mp4

