### PR TITLE
[지출 추가] 화폐 단위 입력시 Int overflow로 인해 크래시나는 부분 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -92,6 +92,7 @@ final class ExpenseAddViewController: UIViewController {
     private func setDelegates() {
         viewModel.delegate = self
         rootView.descriptionTextView.delegate = self
+        rootView.amountTextField.delegate = self
     }
     
     @objc func backButtonTouchUpInside() {
@@ -268,5 +269,29 @@ extension ExpenseAddViewController: UITextViewDelegate {
             textView.text = ExpenseAddView.StringLiteral.descriptionTextViewPlaceholder
             textView.textColor = .grey3
         }
+    }
+}
+
+extension ExpenseAddViewController: UITextFieldDelegate {
+    func textField(
+        _ textField: UITextField,
+        shouldChangeCharactersIn range: NSRange,
+        replacementString string: String
+    ) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                return true
+            }
+        }
+        
+        guard let text = textField.text else { return true }
+        return text.count < Metric.amountTextFieldMaxCount
+    }
+}
+
+fileprivate extension ExpenseAddViewController {
+    enum Metric {
+        static let amountTextFieldMaxCount: Int = 9
     }
 }


### PR DESCRIPTION
## 변경사항
* #149 
* 지출 추가시 지출 액수를 억단위 미만까지밖에 입력 못하도록 수정하여 Int overflow 버그 해결

## 리뷰노트
* TextField delegate 메서드를 활용해 구현하였습니다.

