### PR TITLE
[일정목록] 이름, 내용 줄 수 제한 및 날짜 표시 방식 변경 #173 #174

### DIFF
--- a/Doesaegim/Doesaegim/Data/PlanListSnapshotData.swift
+++ b/Doesaegim/Doesaegim/Data/PlanListSnapshotData.swift
@@ -9,10 +9,11 @@ import Foundation
 
 /// PlanListViewController에서 스냅샷을 생성하는 데 필요한 데이터 
 struct PlanListSnapshotData {
+    typealias Section = Date
 
     // MARK: - Properties
 
-    let section: String
+    let section: Section
 
     let itemID: UUID
 
@@ -21,7 +22,7 @@ struct PlanListSnapshotData {
 
     // MARK: - Init
 
-    init(section: String, itemID: UUID, row: Int? = nil) {
+    init(section: Section, itemID: UUID, row: Int? = nil) {
         self.section = section
         self.itemID = itemID
         self.row = row

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/PlanListViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/PlanListViewModelDelegate.swift
@@ -15,4 +15,6 @@ protocol PlanListViewModelDelegate: AnyObject {
     func planListViewModelDidDeletePlan(_ result: Result<UUID, Error>)
 
     func planListViewModelDidAddPlan(_ result: Result<PlanListSnapshotData, Error>)
+
+    func planListViewModelDidUpdateDateFormat()
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/CheckBox.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/CheckBox.swift
@@ -51,7 +51,6 @@ final class CheckBox: UIButton {
         setImage(.init(systemName: StringLiteral.circledCheckmark), for: .normal)
         setPreferredSymbolConfiguration(.init(pointSize: Metric.imagePointSize), forImageIn: .normal)
     }
-
 }
 
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/DateCollectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/DateCollectionHeaderView.swift
@@ -16,7 +16,7 @@ final class DateCollectionHeaderView: UICollectionReusableView {
 
     private let dateLabel: UILabel = {
         let label = UILabel()
-        label.font = .italicSystemFont(ofSize: FontSize.title)
+        label.changeFontSize(to: FontSize.title)
 
         return label
     }()

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanCollectionViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanCollectionViewCell.swift
@@ -18,8 +18,7 @@ final class PlanCollectionViewCell: UICollectionViewCell {
     private let nameLabel: UILabel = {
         let label = UILabel()
         label.changeFontSize(to: FontSize.body)
-        label.numberOfLines = .zero
-        label.lineBreakMode = .byWordWrapping
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         return label
     }()
@@ -36,9 +35,8 @@ final class PlanCollectionViewCell: UICollectionViewCell {
     private let locationLabel: UILabel = {
         let label = UILabel()
         label.changeFontSize(to: FontSize.caption)
-        label.numberOfLines = .zero
-        label.lineBreakMode = .byWordWrapping
         label.textColor = .grey3
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         return label
     }()
@@ -46,9 +44,8 @@ final class PlanCollectionViewCell: UICollectionViewCell {
     private let contentLabel: UILabel = {
         let label = UILabel()
         label.changeFontSize(to: FontSize.caption)
-        label.numberOfLines = .zero
-        label.lineBreakMode = .byWordWrapping
         label.textColor = .grey3
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         return label
     }()

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/ViewModel/PlanViewModel.swift
@@ -21,17 +21,8 @@ final class PlanViewModel {
         plan.name
     }
 
-    // 9:01 PM 형태의 날짜 문자열 
     var timeString: String? {
-        guard let date = plan.date
-        else {
-            return nil
-        }
-
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-
-        return formatter.string(from: date)
+        plan.date?.userDefaultFormattedTime
     }
 
     var location: String? {

--- a/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+Formatter.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/Date/Date+Formatter.swift
@@ -76,11 +76,17 @@ extension Date {
         return formatter
     }()
 
-    /// 날짜를 22.11.16(수) 형태로 표현한 문자열
-    var shortYearMonthDateString: String {
-        let formatter = DateFormatter()
+    var userDefaultFormattedDate: String {
+        let formatter = Date.convertYearToDayFormatter(with: self)
         formatter.locale = Locale(identifier: LocaleIdentifier.korea)
-        formatter.dateFormat = "yy.MM.dd(E)"
+        formatter.dateFormat += " (E)"
+
+        return formatter.string(from: self)
+    }
+
+    var userDefaultFormattedTime: String {
+        let formatter = Date.convertHourToMinuteFormatter(with: self)
+        formatter.locale = Locale(identifier: LocaleIdentifier.korea)
 
         return formatter.string(from: self)
     }
@@ -165,6 +171,7 @@ extension Date {
         switch formatterState {
         case 0:
             formatter.dateFormat = "a HH:mm"
+            formatter.timeStyle = .short
             formatter.amSymbol = "AM"
             formatter.pmSymbol = "PM"
         case 1:

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIViewController+SetRightBarPlusButton.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIViewController+SetRightBarPlusButton.swift
@@ -17,7 +17,6 @@ extension UIViewController {
         let addButton = UIBarButtonItem(systemItem: .add, primaryAction: UIAction(handler: { _ in
             self.show(viewControllerFactory(), sender: self)
         }))
-        addButton.tintColor = .black
         navigationItem.setRightBarButton(addButton, animated: true)
     }
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- #173 
- #174
- 일정 상세 화면 추가에 따라 목록에서는 제목과 이름이 한 줄만 나타나고 뒤에 내용은 잘리도록 변경했습니다. 
- 환경 설정에서 날짜/시간 표시 방식을 바꾸면 일정 목록에 바로 반영되도록 했습니다. 
  - 환경 설정에 있는 방식으로 날짜 표현을 통일했고 한글은 이탤릭이 안 먹혀서 섹션 헤더의 이탤릭체를 제거했습니다. 
- Date extension에 선언된 기존의 `convertHourToMinuteFormatter(with:)` 메서드가 AM, PM인 경우에도 24시간으로 표시되는 버그를 해결했습니다. 

## 리뷰노트
> 고민, 과정, 궁금한점



## 스크린샷
이름, 내용 레이블의 길이가 1줄로 변경

- 민석님이 말씀해주신 체크박스 사라지는 버그를 수정했습니다. 

|수정 전|수정 후|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/81314063/206955177-c31d8a75-41ef-43d9-b535-edf0a875584c.png" width=200>|<img src="https://user-images.githubusercontent.com/81314063/206970426-ad5866ed-9f55-4787-add1-b4262e7d3bff.png" width=200>|

날짜 변경되는 모습

https://user-images.githubusercontent.com/81314063/206955335-68f935b2-0116-422c-a13b-5ed48e195111.mp4


