### PR TITLE
[지출 추가] 환율 정보 (일본, 인도네시아) 부정확한 환율 버그 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
@@ -17,7 +17,7 @@ final class ExchangeData {
         self.currencyCode = currencyCode
         self.tradingStandardRate = tradingStandardRate
         self.currencyName = currencyName
-        isHundredPer = currencyCode.hasSuffix("(100)") ? true : false
+        isHundredPer = currencyCode.hasSuffix("(100)")
     }
     
     static let list: [ExchangeData] = [

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
@@ -11,13 +11,13 @@ final class ExchangeData {
     let currencyCode: String
     let tradingStandardRate: String
     let currencyName: String
-    var isHundredPer: Bool = false
+    let percent: Double
     
     init(currencyCode: String, tradingStandardRate: String, currencyName: String) {
         self.currencyCode = currencyCode
         self.tradingStandardRate = tradingStandardRate
         self.currencyName = currencyName
-        isHundredPer = currencyCode.hasSuffix("(100)")
+        percent = Double(currencyCode.filter { $0.isNumber }.map { String($0) }.reduce("", +)) ?? 1
     }
     
     static let list: [ExchangeData] = [

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/Model/ExchangeData.swift
@@ -11,11 +11,13 @@ final class ExchangeData {
     let currencyCode: String
     let tradingStandardRate: String
     let currencyName: String
+    var isHundredPer: Bool = false
     
     init(currencyCode: String, tradingStandardRate: String, currencyName: String) {
         self.currencyCode = currencyCode
         self.tradingStandardRate = tradingStandardRate
         self.currencyName = currencyName
+        isHundredPer = currencyCode.hasSuffix("(100)") ? true : false
     }
     
     static let list: [ExchangeData] = [

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -127,8 +127,7 @@ extension ExpenseAddViewController {
         
         if sender == rootView.amountTextField {
             viewModel.isValidAmountTextField(text: sender.text)
-            guard let exchangeInfo else { return }
-            viewModel.exchangeLabelShow(amount: sender.text, unit: exchangeInfo.tradingStandardRate)
+            viewModel.exchangeLabelShow(amount: sender.text, exchangeInfo: exchangeInfo)
             return
         }
     }
@@ -171,7 +170,7 @@ extension ExpenseAddViewController: ExpenseAddPickerViewDelegate {
         let title = "\(exchangeRateType.icon) \(item.currencyName)"
         rootView.moneyUnitButton.setTitle(title, for: .normal)
         viewModel.isValidUnitItem(item: title)
-        viewModel.exchangeLabelShow(amount: rootView.amountTextField.text, unit: item.tradingStandardRate)
+        viewModel.exchangeLabelShow(amount: rootView.amountTextField.text, exchangeInfo: item)
     }
     
     func selectedCategory(item: ExpenseType) {

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
@@ -123,8 +123,7 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
             exchangeCalculataion = -1
             return
         }
-        exchangeCalculataion = exchangeInfo.isHundredPer ?
-        Int(rationalUnit * rationalAmount * 0.01) : Int(rationalUnit * rationalAmount)
+        exchangeCalculataion = Int(rationalUnit * rationalAmount * 1 / exchangeInfo.percent)
     }
     
     func addExpense(
@@ -147,13 +146,11 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
             return .failure(CoreDataError.saveFailure(.expense))
         }
         let newContent = content == StringLiteral.descriptionTextViewPlaceholder ? "" : (content ?? "")
-        let newCost = exchangeInfo.isHundredPer ?
-        Int64(cost * tradingStandardRate * 0.01) : Int64(cost * tradingStandardRate)
         let expenseDTO = ExpenseDTO(
             name: name,
             category: category,
             content: newContent,
-            cost: Int64(cost * tradingStandardRate),
+            cost: Int64(cost * tradingStandardRate * (1 / exchangeInfo.percent)),
             currency: exchangeInfo.currencyName,
             date: date,
             travel: travel)

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
@@ -115,14 +115,16 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
         isValidDate = true
     }
     
-    func exchangeLabelShow(amount: String?, unit: String) {
+    func exchangeLabelShow(amount: String?, exchangeInfo: ExchangeData?) {
         guard let amount,
+              let exchangeInfo,
               let rationalAmount = Double(amount),
-              let rationalUnit = Double(unit.convertRemoveComma()) else {
+              let rationalUnit = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()) else {
             exchangeCalculataion = -1
             return
         }
-        exchangeCalculataion = Int(rationalAmount * rationalUnit)
+        exchangeCalculataion = exchangeInfo.isHundredPer ?
+        Int(rationalUnit * rationalAmount * 0.01) : Int(rationalUnit * rationalAmount)
     }
     
     func addExpense(
@@ -145,11 +147,13 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
             return .failure(CoreDataError.saveFailure(.expense))
         }
         let newContent = content == StringLiteral.descriptionTextViewPlaceholder ? "" : (content ?? "")
+        let newCost = exchangeInfo.isHundredPer ?
+        Int64(cost * tradingStandardRate * 0.01) : Int64(cost * tradingStandardRate)
         let expenseDTO = ExpenseDTO(
             name: name,
             category: category,
             content: newContent,
-            cost: Int64(cost * tradingStandardRate) ,
+            cost: Int64(cost * tradingStandardRate),
             currency: exchangeInfo.currencyName,
             date: date,
             travel: travel)

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
@@ -32,7 +32,7 @@ protocol ExpenseAddViewProtocol: AnyObject {
         date: String?,
         description: String?
     )
-    func exchangeLabelShow(amount: String?, unit: String)
+    func exchangeLabelShow(amount: String?, exchangeInfo: ExchangeData?)
     func addExpense(
         name: String?,
         category: String?,


### PR DESCRIPTION
## 변경사항
* #148
* response의 통화코드에 숫자가 포함되어 있다면, 환율에 1/숫자를 곱한 값으로 표현되도록 구현하였습니다.

## 리뷰노트
* 통화 코드에 숫자가 포함되어있다면 1 / 숫자를 곱하는 로직으로 구현하였는데 더 나은 방법이 있을지.. 궁금하네요 ㅠ

