### PR TITLE
[지출 목록 조회] 관련 이슈 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -86,10 +86,7 @@ final class ExpenseListViewController: UIViewController {
         }
         
         placeholdView.snp.makeConstraints {
-            $0.centerX.equalTo(view.snp.centerX)
-            $0.centerY.equalTo(view.snp.centerY).multipliedBy(1.3)
-            $0.width.equalTo(view.bounds.width - 100)
-            $0.height.equalTo(50)
+            $0.edges.equalToSuperview()
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -28,6 +28,8 @@ final class ExpenseListViewController: UIViewController {
         
         collectionView.backgroundColor = .white
         collectionView.layer.cornerRadius = 12
+        collectionView.allowsSelection = false
+        
         return collectionView
     }()
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpensePlaceholdView.swift
@@ -7,14 +7,30 @@
 
 import UIKit
 
+import SnapKit
+
 final class ExpensePlaceholdView: UIView {
     
     // MARK: - Properties
     
-    let mainLabel: UILabel = {
+    private lazy var blurBackgroundView: UIVisualEffectView = {
+        let blurEffect = UIBlurEffect(style: .regular)
+        let visualEffectView = UIVisualEffectView(effect: blurEffect)
+        visualEffectView.frame = bounds
+        visualEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
+        return visualEffectView
+    }()
+    
+    private let mainLabel: UILabel = {
         let label = UILabel()
         label.textColor = .primaryOrange
+        label.textAlignment = .center
         label.text = "지출 내역이 없어요!"
+        
+        label.layer.cornerRadius = 7
+        label.layer.borderColor = UIColor.primaryOrange?.cgColor
+        label.layer.borderWidth = 1
         
         return label
     }()
@@ -35,25 +51,18 @@ final class ExpensePlaceholdView: UIView {
     
     private func configure() {
         configureSubviews()
-        configureStyle()
         configureContstraints()
     }
     
     private func configureSubviews() {
-        addSubview(mainLabel)
-    }
-    
-    private func configureStyle() {
-        backgroundColor = .white
-        layer.cornerRadius = 7
-        layer.borderColor = UIColor.primaryOrange?.cgColor
-        layer.borderWidth = 1
+        addSubviews(blurBackgroundView, mainLabel)
     }
     
     private func configureContstraints() {
         mainLabel.snp.makeConstraints {
-            $0.centerX.equalTo(self.snp.centerX)
-            $0.centerY.equalTo(self.snp.centerY)
+            $0.horizontalEdges.equalTo(snp.horizontalEdges).inset(50)
+            $0.centerY.equalTo(snp.centerY).multipliedBy(1.3)
+            $0.height.equalTo(50)
         }
     }
 }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 지출 목록 셀이 선택되는 효과를 막았습니다.
- 지출 목록이 비어 있을 때 화면 전체에 블러처리 효과를 표시하도록 수정했습니다.

## 관련 이슈
- resolves #163 

## 리뷰노트
> 고민, 과정, 궁금한점

## 스크린샷
수정 전 문제가 되었던 버그와 수정 후 모습입니다!

https://user-images.githubusercontent.com/50136980/206959179-4bcf57ed-ac51-46ab-9740-24078996022f.mp4

<img src="https://user-images.githubusercontent.com/50136980/206959303-16619d06-3cd6-4067-9f27-24b8f01eaec8.png" width="33%">

