### PR TITLE
[지출 목록 조회] 섹션 헤더에서 날짜가 제대로 표시되지 않던 문제 수정

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -172,11 +172,9 @@ final class ExpenseListViewController: UIViewController {
     
     private func configureCollectionViewDataSource() {
         
-        var date: Date?
+        var sections: [String]?
         let expenseCell = CellRegistration { cell, _, identifier in
             cell.configureContent(with: identifier)
-            // TODO: - 페이지네이션
-            date = identifier.date
         }
         
         expenseDataSource = DataSource(
@@ -199,7 +197,8 @@ final class ExpenseListViewController: UIViewController {
         
         let sectionHeaderRegistration = SectionHeaderRegistration(
             elementKind: HeaderKind.sectionHeader
-        ) { _, _, _ in
+        ) { [weak self] supplementaryView, _, _ in
+            sections = self?.viewModel?.sections
         }
         
         expenseDataSource?.supplementaryViewProvider = { (collectionView, kind, indexPath) in
@@ -216,7 +215,7 @@ final class ExpenseListViewController: UIViewController {
                 using: sectionHeaderRegistration,
                 for: indexPath
             )
-            sectionHeader.configureData(date: date)
+            sectionHeader.configureData(dateString: sections?[safeIndex: indexPath.section])
             return sectionHeader
         }
         

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -49,8 +49,7 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     
     func configureData(date: Date?) {
         guard let date else { return }
-        let formatter = Date.yearMonthDayDateFormatter
-        let dateString = formatter.string(from: date)
+        let dateString = date.userDefaultFormattedDate
         
         dateLabel.text = dateString
     }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -47,9 +47,8 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
         }
     }
     
-    func configureData(date: Date?) {
-        guard let date else { return }
-        let dateString = date.userDefaultFormattedDate
+    func configureData(dateString: String?) {
+        guard let dateString else { return }
         
         dateLabel.text = dateString
     }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 섹션 헤더의 날짜가 제대로 표시되지 않고, 스크롤 할 때도 다르게 표시되는 문제를 수정했습니다.

## 관련 이슈
- resolves #163 

## 리뷰노트
> 고민, 과정, 궁금한점
- 처음에는 지출 목록이 날짜별로 묶이지 않아서 발생한 문제라고 생각하고 삽질할 뻔 했지만 이후 표기 값만 잘못 되었다는 것을 알고 생각보다 빠르게 고칠 수 있었습니다👍

## 스크린샷

섹션 헤더 오류가 발생했을 때의 스크린샷입니다! 동일한 날짜가 연속해서 표시되고 있고, 스크롤 하면 그 값이 바뀌는 것을 확인할 수 있습니다.

https://user-images.githubusercontent.com/50136980/206999015-29116d12-d4ec-404e-887d-1834216ee831.mp4

아래는 수정 후 섹션 헤더 모습입니다!

https://user-images.githubusercontent.com/50136980/207012437-7f819236-5c05-49e9-8f0b-9963275e1bbc.mp4


