### PR TITLE
[여행 수정] 여행 수정 기능 추가

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -22,7 +22,6 @@ final class PlanListViewController: UIViewController {
 
     private lazy var dataSource = configureDataSource()
 
-
     // MARK: - Properties
 
     private let viewModel: PlanListViewModel
@@ -93,7 +92,10 @@ final class PlanListViewController: UIViewController {
         let moveToUpdateTravelAction = UIAction(
             title: "여행 수정 하기"
         ) { [weak self] _ in
-            let travelAddViewController = TravelAddViewController()
+            let travelAddViewController = TravelAddViewController(
+                mode: .update,
+                travel: self?.viewModel.travel
+            )
             self?.navigationController?.pushViewController(travelAddViewController, animated: true)
         }
         let cancel = UIAction(title: "취소", attributes: .destructive) { _ in }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanList/View/PlanListViewController.swift
@@ -71,15 +71,39 @@ final class PlanListViewController: UIViewController {
 
     private func configureNavigationBar() {
         navigationItem.title = viewModel.navigationTitle
-        setRightBarAddButton { [weak self] in
-            if let travel = self?.viewModel.travel {
-                let planAddViewController = PlanAddViewController(travel: travel)
-                planAddViewController.delegate = self
-                return planAddViewController
-            } else {
-                return UIViewController()
+        let ellipsisButton = UIBarButtonItem(
+            image: UIImage(systemName: "ellipsis"),
+            style: .plain,
+            target: self,
+            action: nil
+        )
+        
+        let moveToPlanAddViewControllerAction = UIAction(
+            title: "일정 추가 하기"
+        ) { [weak self] _  in
+                if let travel = self?.viewModel.travel {
+                    let planAddViewController = PlanAddViewController(travel: travel)
+                    planAddViewController.delegate = self
+                    self?.navigationController?.pushViewController(planAddViewController, animated: true)
+                } else {
+                    self?.presentErrorAlert(title: "일정을 추가할 수 없어요.")
+                }
             }
+        
+        let moveToUpdateTravelAction = UIAction(
+            title: "여행 수정 하기"
+        ) { [weak self] _ in
+            let travelAddViewController = TravelAddViewController()
+            self?.navigationController?.pushViewController(travelAddViewController, animated: true)
         }
+        let cancel = UIAction(title: "취소", attributes: .destructive) { _ in }
+        
+        ellipsisButton.menu = UIMenu(
+            title: "이동하기",
+            options: .displayInline,
+            children: [moveToPlanAddViewControllerAction,moveToUpdateTravelAction, cancel]
+        )
+        navigationItem.rightBarButtonItem = ellipsisButton
     }
 
 

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddView.swift
@@ -128,9 +128,11 @@ final class TravelAddView: UIView {
         return customCalendar
     }()
     
-    // MARK: - Lifecycles
+    // MARK: - Properties
+    private let mode: TravelAddViewController.Mode
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, mode: TravelAddViewController.Mode) {
+        self.mode = mode
         super.init(frame: frame)
         configureViews()
     }
@@ -202,7 +204,6 @@ final class TravelAddView: UIView {
             $0.height.equalTo(48)
         }
     }
-    
 }
 
 extension TravelAddView {

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -128,6 +128,7 @@ final class TravelAddViewController: UIViewController {
         rootView.travelDateStartLabel.textColor = .black
         rootView.travelDateEndLabel.textColor = .black
         rootView.customCalendar.initUpdateMode(start: startDate, end: endDate)
+        rootView.addButton.setTitle("여행 수정", for: .normal)
         viewModel.isValidInput = true
         viewModel.isValidDate = true
         viewModel.isValidTextField = true

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -13,17 +13,21 @@ final class TravelAddViewController: UIViewController {
     
     // MARK: - UI properties
     
-    private let rootView = TravelAddView()
+    private lazy var rootView = TravelAddView(frame: .zero, mode: mode)
     
     // MARK: - Properties
     
     private let viewModel: TravelAddViewModel
     private let dateFormatter: DateFormatter = Date.yearMonthDayDateFormatter
+    private let mode: Mode
+    private let travel: Travel?
     
     // MARK: - Lifecycles
     
-    init() {
+    init(mode: Mode, travel: Travel? = nil) {
         viewModel = TravelAddViewModel()
+        self.mode = mode
+        self.travel = travel
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -43,6 +47,9 @@ final class TravelAddViewController: UIViewController {
         setDelegate()
         setAddTargets()
         bindCalendar()
+        if mode == .update {
+            initUpdateMode()
+        }
     }
     
     deinit {
@@ -56,7 +63,7 @@ final class TravelAddViewController: UIViewController {
     }
     
     private func configureNavigationBar() {
-        navigationItem.title = "여행 추가"
+        navigationItem.title = mode == .post ? "여행 추가" : "여행 수정"
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "chevron.backward"),
             style: .done,
@@ -107,6 +114,19 @@ final class TravelAddViewController: UIViewController {
         viewModel.delegate = self
         rootView.travelTitleTextField.delegate = self
     }
+    
+    // MARK: - UpdateMode
+    
+    private func initUpdateMode() {
+        guard let travel, let startDate = travel.startDate, let endDate = travel.endDate else { return }
+        rootView.travelTitleTextField.text = travel.name
+        rootView.travelDateStartLabel.text = Date.yearMonthDayDateFormatter.string(from: startDate)
+        rootView.travelDateEndLabel.text = Date.yearMonthDayDateFormatter.string(from: endDate)
+        rootView.travelDateStartLabel.textColor = .black
+        rootView.travelDateEndLabel.textColor = .black
+        rootView.customCalendar.initUpdateMode(start: startDate, end: endDate)
+    }
+    
 }
 
 // MARK: - Keyboard
@@ -210,5 +230,14 @@ extension TravelAddViewController: TravelAddViewDelegate {
         } else {
             navigationController?.popViewController(animated: true)
         }
+    }
+}
+
+// MARK: Enums
+
+extension TravelAddViewController {
+    enum Mode {
+        case post
+        case update
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/View/TravelAddViewController.swift
@@ -79,6 +79,9 @@ final class TravelAddViewController: UIViewController {
         rootView.customCalendar.completionHandler = { [weak self] dates in
             self?.viewModel.travelDateTapped(dates: dates) { isSuccess in
                 guard isSuccess, let startDate = dates.first, let endDate = dates.last else {
+                    return
+                }
+                if startDate > endDate {
                     self?.presentErrorAlert(title: "날짜를 다시 입력해주세요")
                     return
                 }
@@ -125,6 +128,9 @@ final class TravelAddViewController: UIViewController {
         rootView.travelDateStartLabel.textColor = .black
         rootView.travelDateEndLabel.textColor = .black
         rootView.customCalendar.initUpdateMode(start: startDate, end: endDate)
+        viewModel.isValidInput = true
+        viewModel.isValidDate = true
+        viewModel.isValidTextField = true
     }
     
 }
@@ -184,17 +190,32 @@ extension TravelAddViewController {
     }
     
     @objc func addButtonTouchUpInside() {
-        let result = viewModel.addTravel(
-            name: rootView.travelTitleTextField.text,
-            startDateString: rootView.travelDateStartLabel.text,
-            endDateString: rootView.travelDateEndLabel.text
-        )
-        switch result {
-        case .success:
-            navigationController?.popViewController(animated: true)
-        case .failure(let error):
-            presentErrorAlert(title: CoreDataError.saveFailure(.travel).errorDescription)
-            print(error.localizedDescription)
+        if mode == .post {
+            let result = viewModel.addTravel(
+                name: rootView.travelTitleTextField.text,
+                startDateString: rootView.travelDateStartLabel.text,
+                endDateString: rootView.travelDateEndLabel.text
+            )
+            switch result {
+            case .success:
+                navigationController?.popViewController(animated: true)
+            case .failure(let error):
+                presentErrorAlert(title: CoreDataError.saveFailure(.travel).errorDescription)
+                print(error.localizedDescription)
+            }
+        } else {
+            let result = viewModel.updateTravel(
+                name: rootView.travelTitleTextField.text,
+                startDate: rootView.customCalendar.selectedDates.first,
+                endDate: rootView.customCalendar.selectedDates.last,
+                travel: travel)
+            switch result {
+            case .success:
+                navigationController?.popToRootViewController(animated: true)
+            case .failure(let error):
+                presentErrorAlert(title: CoreDataError.updateFailure(.travel).errorDescription)
+                print(error.localizedDescription)
+            }
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelAdd/ViewModel/TravelAddViewModel.swift
@@ -88,4 +88,35 @@ final class TravelAddViewModel: TravelAddViewProtocol {
         let travelDTO = TravelDTO(name: name, startDate: startDate, endDate: endDate)
         return repository.addTravel(travelDTO)
     }
+    
+    func updateTravel(
+        name: String?,
+        startDate: Date?,
+        endDate: Date?,
+        travel: Travel?
+    ) -> Result<Bool, Error> {
+        guard let travel,
+              let name,
+              let startDate,
+              let endDate else {
+            return .failure(CoreDataError.fetchFailure(.travel))
+        }
+        let result = PersistentRepository.shared.fetchTravel()
+        switch result {
+        case .success(let travels):
+            let updateTravels = travels.filter({ $0.id == travel.id })
+            guard let updateTravel = updateTravels.last
+            else {
+                return .failure(CoreDataError.fetchFailure(.travel))
+            }
+            updateTravel.setValue(name, forKey: "name")
+            updateTravel.setValue(startDate, forKey: "startDate")
+            updateTravel.setValue(endDate, forKey: "endDate")
+            return PersistentManager.shared.saveContext()
+            
+        case .failure(let error):
+            print(error.localizedDescription)
+            return .failure(CoreDataError.updateFailure(.travel))
+        }
+    }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelListViewController.swift
@@ -158,7 +158,7 @@ final class TravelListViewController: UIViewController {
     
     @objc func didAddTravelButtonTap() {
         // 여행 추가 뷰컨트롤러 이동
-        navigationController?.pushViewController(TravelAddViewController(), animated: true)
+        navigationController?.pushViewController(TravelAddViewController(mode: .post), animated: true)
     }
 }
 

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
@@ -33,14 +33,14 @@ final class CustomCalendar: UICollectionView {
     
     private var diffableDatasource: Datasource?
     private var today = Date()
-    private var calendar = Calendar(identifier: .gregorian)
+    private var calendar = Calendar.current
     private var dateComponents = DateComponents()
     private let dateFormmater = Date.yearMonthDateFormatter
     private let weeks: [String] = ["일", "월", "화", "수", "목", "금", "토"]
     private var days: [Item] = []
     private let touchOption: TouchOption
     private var selectedCount = 0
-    private var selectedDates: [Date] = []
+    var selectedDates: [Date] = []
     
     var startDate: Date?
     var endDate: Date?
@@ -174,8 +174,10 @@ final class CustomCalendar: UICollectionView {
     private func setupCalendar(date: Date) {
         /// 현재 Month의 1일이 무슨 요일인지 인덱스로 알려줌
         /// 0부터 월요일
-        let firstWeekIndex = calendar.component(.weekday, from: date) - 1
         
+        guard let firstDayOfMonth = calendar.date(from: dateComponents) else { return }
+        let firstWeekIndex = calendar.component(.weekday, from: firstDayOfMonth) - 1
+        print("firstWeekIndex: ",firstWeekIndex)
         /// 마지막 날짜
         /// ex) 2월 - 28, 12월- 31
         let endOfday = calendar.range(of: .day, in: .month, for: date)?.count ?? 31
@@ -271,6 +273,7 @@ extension CustomCalendar {
     }
     
     func initUpdateMode(start: Date, end: Date) {
+        selectedDates.removeAll()
         selectedDates = [start, end]
         selectedCount = 2
         setupCalendar(date: start)
@@ -282,7 +285,8 @@ extension CustomCalendar {
 
 extension CustomCalendar: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let startDay = calendar.component(.weekday, from: today) - 1
+        guard let firstDayOfMonth = calendar.date(from: dateComponents) else { return }
+        let startDay = calendar.component(.weekday, from: firstDayOfMonth) - 1
         
         guard days[indexPath.row].isSelectable else { return }
         
@@ -303,7 +307,7 @@ extension CustomCalendar: UICollectionViewDelegate {
         
         guard let date = Date.yearMonthDayDateFormatter.date(from: stringDate) else { return }
         selectedDates.append(date)
-        
+        print("##", startDay, today)
         switch touchOption {
         case .single:
             completionHandler?(selectedDates)
@@ -312,6 +316,7 @@ extension CustomCalendar: UICollectionViewDelegate {
             configureSnapshot()
             days = days.map { Item(date: $0.date, isSelected: false, isSelectable: $0.isSelectable) }
         case .double:
+            completionHandler?(selectedDates)
             if selectedCount == 1 {
                 if let selectedDate = selectedDates.first {
                     days = days.map {
@@ -325,7 +330,6 @@ extension CustomCalendar: UICollectionViewDelegate {
                 guard let startDate = selectedDates.first, let endDate = selectedDates.last else {
                     return
                 }
-                completionHandler?(selectedDates)
                 days = days.map {
                     let isPeriodDate = isPeriodDate(start: startDate, end: endDate, current: $0.date)
                     return Item(

--- a/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
+++ b/Doesaegim/Doesaegim/Utility/Custom/Calendar/CustomCalendar.swift
@@ -165,20 +165,20 @@ final class CustomCalendar: UICollectionView {
     private func configureCalendar() {
         dateComponents.year = calendar.component(.year, from: today)
         dateComponents.month = calendar.component(.month, from: today)
-        setupCalendar()
+        setupCalendar(date: today)
         configureSnapshot()
     }
     
     
     /// 캘린더 설정 함수
-    private func setupCalendar() {
+    private func setupCalendar(date: Date) {
         /// 현재 Month의 1일이 무슨 요일인지 인덱스로 알려줌
         /// 0부터 월요일
-        let firstWeekIndex = calendar.component(.weekday, from: today) - 1
+        let firstWeekIndex = calendar.component(.weekday, from: date) - 1
         
         /// 마지막 날짜
         /// ex) 2월 - 28, 12월- 31
-        let endOfday = calendar.range(of: .day, in: .month, for: today)?.count ?? 31
+        let endOfday = calendar.range(of: .day, in: .month, for: date)?.count ?? 31
         
         /// 모든 날짜의 합을 알려줌
         /// ex) 2022년 11월  화요일 시작 (2) + 30일까지 있음 (30)
@@ -268,6 +268,13 @@ extension CustomCalendar {
                 }
             }
         }
+    }
+    
+    func initUpdateMode(start: Date, end: Date) {
+        selectedDates = [start, end]
+        selectedCount = 2
+        setupCalendar(date: start)
+        configureSnapshot()
     }
 }
 

--- a/Doesaegim/Doesaegim/Utility/Errors/CoreDataError.swift
+++ b/Doesaegim/Doesaegim/Utility/Errors/CoreDataError.swift
@@ -11,6 +11,7 @@ enum CoreDataError: LocalizedError {
     case fetchFailure(EntityType)
     case saveFailure(EntityType)
     case deleteFailure(EntityType)
+    case updateFailure(EntityType)
 
     var errorDescription: String? {
         switch self {
@@ -20,6 +21,8 @@ enum CoreDataError: LocalizedError {
             return NSLocalizedString("\(entityType) 변경사항을 저장하는 데 실패했습니다", comment: "save failure")
         case .deleteFailure(let entityType):
             return NSLocalizedString("\(entityType) 정보를 삭제하는 데 실패했습니다", comment: "delete failure")
+        case .updateFailure(let entityType):
+            return NSLocalizedString("\(entityType) 정보를 수정하는 데 실패했습니다", comment: "delete failure")
         }
     }
 }


### PR DESCRIPTION
## 변경사항
* 일정 목록화면에서 일정추가, 여행 수정 화면으로 진입할 수 있도록 UIMenu를 구현하였습니다.
* 여행 수정 기능을 구현하였습니다.
* 커스텀 캘린더가 실제 달력과 동일하지 않은 오류를 수정하였습니다.

## 리뷰노트
* 여행 수정 화면이 여행 추가 화면과 완전 동일해서 TravelAddViewController에 Enum으로 mode를 두어 수정화면일 때만 실행시키도록 구현하였는데, 수정 화면에 따른 새로운 뷰컨트롤러를 만드는 게 더 나았을지..? 고민이 되었습니다.
* 여행 수정시 여행 목록화면에 바로 반영이 안되고 있습니다..!
  * viewWillAppear()에서 fetch를 하고 있는데 여행 추가시에는 바로 반영이 되는데 수정시에는 안되는 이유가 있을까요..?!😅

## 스크린샷
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/77199797/207033654-17702de1-f1a5-44ba-b25c-230c8f5d7e6f.gif)

