### PR TITLE
[다이어리 편집] 편집 관련 기능 개선

### DIFF
--- a/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/DiaryDTO.swift
@@ -13,6 +13,6 @@ struct DiaryDTO {
     let date: Date
     let images: [String]
     let title: String
-    let location: LocationDTO
+    let location: LocationDTO?
     let travel: Travel
 }

--- a/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/TemporaryDiary.swift
@@ -18,15 +18,14 @@ struct TemporaryDiary {
     var content: String?
     var imagePaths = [String]()
 
-    /// 필수 항목(여행, 장소, 날짜, 제목, 내용)이 작성되었는 지 여부
+    /// 필수 항목(여행, 날짜, 제목, 내용)이 작성되었는 지 여부
     var hasAllRequiredProperties: Bool {
         let hasTravel = travel != nil
-        let hasLocation = location != nil
         let hasDate = date != nil
         let hasTitle = title?.isEmpty == false
         let hasContent = content?.isEmpty == false
 
-        return hasTravel && hasLocation && hasDate && hasTitle && hasContent
+        return hasTravel && hasDate && hasTitle && hasContent
     }
 
     var dateString: String {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -200,7 +200,6 @@ final class DiaryAddViewModel {
     private func addDiary() -> Result<Diary, Error> {
         guard let title = temporaryDiary.title,
               let content = temporaryDiary.content,
-              let location = temporaryDiary.location,
               let travel = temporaryDiary.travel,
               let date = temporaryDiary.date
         else {
@@ -213,7 +212,7 @@ final class DiaryAddViewModel {
             date: date,
             images: temporaryDiary.imagePaths,
             title: title,
-            location: location,
+            location: temporaryDiary.location,
             travel: travel
         )
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryAdd/ViewModel/DiaryAddViewModel.swift
@@ -60,6 +60,14 @@ final class DiaryAddViewModel {
 
     func travelDidSelect(_ travel: Travel) {
         temporaryDiary.travel = travel
+        if let date = temporaryDiary.date,
+           let startDate = travel.startDate,
+           let endDate = travel.endDate,
+           let dateAfterEndDate = Calendar.current.date(byAdding: .day, value: 1, to: endDate),
+           !(startDate..<dateAfterEndDate ~= date) {
+            /// 여행 변경 후 기존에 설정한 날짜가 여행의 기간을 벗어나는 경우 무효화
+            temporaryDiary.date = nil
+        }
         delegate?.diaryAddViewModelValuesDidChange(temporaryDiary)
     }
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailView.swift
@@ -27,6 +27,15 @@ final class DiaryDetailView: UIView {
         
         return slider
     }()
+
+    /// 제목 레이블
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = Metric.contentNumberOfLines
+        label.font = .boldSystemFont(ofSize: FontSize.title)
+
+        return label
+    }()
     
     /// 내용 레이블
     private let contentLabel: UILabel = {
@@ -98,6 +107,7 @@ final class DiaryDetailView: UIView {
     /// 다이어리 객체를 받아와 각 뷰의 요소를 설정한다.
     /// - Parameter diary: 화면에 표시할 다이어리 객체
     func setupData(diary: Diary) {
+        titleLabel.text = diary.title
         contentLabel.text = diary.content
         if let locationName = diary.location?.name {
             locationLabel.text = locationName
@@ -134,7 +144,7 @@ final class DiaryDetailView: UIView {
     
     private func configureSubviews() {
         infoStack.addArrangedSubviews(locationLabel, dateLabel)
-        contentStack.addArrangedSubviews(imageSlider, contentLabel, infoStack)
+        contentStack.addArrangedSubviews(imageSlider, titleLabel, contentLabel, infoStack)
         
         scrollView.addSubview(contentStack)
         addSubviews(scrollView, activityIndicatorView)
@@ -142,7 +152,7 @@ final class DiaryDetailView: UIView {
     
     private func configureConstraint() {
         imageSlider.snp.makeConstraints { $0.height.equalTo(imageSlider.snp.width) }
-        [contentLabel, infoStack].forEach {
+        [titleLabel, contentLabel, infoStack].forEach {
             $0.snp.makeConstraints {
                 $0.leading.equalToSuperview().inset(Metric.contentInsets)
             }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -170,10 +170,6 @@ final class DiaryDetailViewController: UIViewController {
 
 extension DiaryDetailViewController: DiaryDetailViewModelDelegate {
     
-    func diaryDetailTitleDidFetch(with title: String?) {
-        navigationItem.title = title
-    }
-    
     func diaryDetailDidFetch(diary: Diary) {
         rootView.setupData(diary: diary)
     }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModel.swift
@@ -50,7 +50,6 @@ final class DiaryDetailViewModel {
     // MARK: - Functions
     
     func fetchDiaryDetail() {
-        delegate?.diaryDetailTitleDidFetch(with: navigationTitle)
         delegate?.diaryDetailDidFetch(diary: diary)
         
         guard let paths = diary.images,

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModelDelegate.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/ViewModel/DiaryDetailViewModelDelegate.swift
@@ -9,8 +9,6 @@ import Foundation
 
 protocol DiaryDetailViewModelDelegate: AnyObject {
     
-    func diaryDetailTitleDidFetch(with title: String?)
-    
     func diaryDetailDidFetch(diary: Diary)
     
     func diaryDetailImageSliderPagesDidFetch(_ count: Int)

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryEdit/ViewModel/DiaryEditViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryEdit/ViewModel/DiaryEditViewModel.swift
@@ -244,7 +244,6 @@ final class DiaryEditViewModel {
     private func saveDiary() -> Result<Bool, Error> {
         guard let title = temporaryDiary.title,
               let content = temporaryDiary.content,
-              let location = temporaryDiary.location,
               let travel = temporaryDiary.travel,
               let previousTravel = diary.travel,
               let date = temporaryDiary.date
@@ -259,12 +258,32 @@ final class DiaryEditViewModel {
         diary.title = title
         diary.date = date
         diary.content = content
+        diary.images = temporaryDiary.imagePaths
+        updateLocation()
+
+        return repository.saveDiary()
+    }
+
+    private func updateLocation() {
+        guard let location = temporaryDiary.location
+        else {
+            return
+        }
+
+        guard diary.location != nil
+        else {
+            let dto = LocationDTO(
+                name: location.name,
+                latitude: location.latitude,
+                longitude: location.longitude
+            )
+            diary.location = Location.add(with: dto)
+            return
+        }
+
         diary.location?.name = location.name
         diary.location?.latitude = location.latitude
         diary.location?.longitude = location.longitude
-        diary.images = temporaryDiary.imagePaths
-
-        return repository.saveDiary()
     }
 
     private func deleteImagesInFileSystem() {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryEdit/ViewModel/DiaryEditViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryEdit/ViewModel/DiaryEditViewModel.swift
@@ -93,6 +93,13 @@ final class DiaryEditViewModel {
 
     func travelDidSelect(_ travel: Travel) {
         temporaryDiary.travel = travel
+        if let date = temporaryDiary.date,
+           let startDate = travel.startDate,
+           let endDate = travel.endDate,
+           let dateAfterEndDate = Calendar.current.date(byAdding: .day, value: 1, to: endDate),
+           !(startDate..<dateAfterEndDate ~= date) {
+            temporaryDiary.date = nil
+        }
         delegate?.diaryEditViewModelValuesDidChange(temporaryDiary)
     }
 

--- a/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Diary+CoreDataClass.swift
@@ -24,8 +24,10 @@ public class Diary: NSManagedObject {
         diary.title = object.title
         diary.content = object.content
 
-        let location = Location.add(with: object.location)
-        diary.location = location
+        if let locationDTO = object.location {
+            let location = Location.add(with: locationDTO)
+            diary.location = location
+        }
         
         object.travel.addToDiary(diary)
         


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- #171

- 다이어리 작성 시 장소 입력을 선택적으로 할 수 있도록 변경했습니다. 
- 다이어리 추가/수정 시에 다이어리의 기존 날짜가 새로 선택한 여행의 기간을 벗어나는 경우를 처리했습니다. 
  - 생각도 못하고 있다가 민석님이 말씀해주셔서 기간을 벗어나는 경우 기존 선택한 날짜를 nil로 변경하도록 했습니다. 
- 다이어리 디테일 화면에 제목 레이블을 추가했습니다. 
 
## 리뷰노트
>>> 고민, 과정, 궁금한점

## 스크린샷

장소 없이 다이어리 추가 

https://user-images.githubusercontent.com/81314063/207045215-37ada8d6-1f75-475f-8a90-eccfeb74ec5c.mp4


여행 변경에 따라 날짜가 여행 기간을 벗어나는 경우 날짜 초기화 

https://user-images.githubusercontent.com/81314063/207045657-1b320e3d-6988-4848-8b3a-0676ef7b3cfc.mp4


다이어리 제목 레이블 추가 

<img src="https://user-images.githubusercontent.com/81314063/207044936-cf604442-bdef-4564-be42-9c37bd29da0f.png" width=300>