### PR TITLE
[커스텀 그래프] 버그 수정 및 텍스트 이슈 수정

### DIFF
--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
@@ -19,11 +19,21 @@ final class BarBackgroundLayer: CAShapeLayer {
     
     private let maxCost: CGFloat
     
-    /// maxCost를 기준으로 0 ~ maxCost 사이의 값을 n등분하여 배열로 저장하는 프로퍼티. 0과 maxCost는 포함되지 않고 사잇값만 저장한다.
+    /// n의 자릿수를 가지는 maxCost를 n-2자리에서 올림한 값. ex) 1234 -> 1300
+    /// 만일 `n <= 2`라면 maxCost를 그대로 리턴한다.
+    private var maxStandard: CGFloat {
+        let digit = CGFloat(String(Int(maxCost)).count - 2)
+        
+        guard digit > 0 else { return maxCost }
+        let maxStandard: CGFloat = ceil(maxCost * pow(0.1, digit)) * pow(10, digit)
+        
+        return maxStandard
+    }
+    
+    /// maxCost를 기준으로 0 ~ maxStandard 사이의 값을 n등분하여 배열로 저장하는 프로퍼티. 0과 maxCost는 포함되지 않고 사잇값만 저장한다.
     private var costStandards: [CGFloat] {
-        var array: [CGFloat] = []
-        for order in 1 ..< Metric.dividerCount {
-            array.append(maxCost / CGFloat(Metric.dividerCount) * CGFloat(order))
+        let array: [CGFloat] = (1 ..< Metric.dividerCount).map {
+            maxStandard / CGFloat(Metric.dividerCount) * CGFloat($0)
         }
         
         return array
@@ -120,15 +130,18 @@ final class BarBackgroundLayer: CAShapeLayer {
     
     /// 배경의 좌측에 최고 금액을 기준으로 나눈 금액 단위를 표시한다.
     private func configureCostTextLayer(with index: Int) {
-        guard let willDisplayCost = costStandards[safeIndex: index] else { return }
+        guard let willDisplayCost = costStandards[safeIndex: index],
+              !costStandards.isEmpty,
+              maxCost != 0
+        else { return }
         
-        let costWidth = inset.width
-        let costHeight = (rect.height - inset.height) / CGFloat(costStandards.count + 1)
+        let costWidth = inset.width - Metric.costTextToLinePadding
+        let costHeight = (rect.height - inset.height) / CGFloat(costStandards.count)
         let baseY = rect.maxY - inset.height
         
         let costTextFrame = CGRect(
-            x: rect.minX,
-            y: baseY - costHeight * CGFloat(index + 1),
+            x: rect.minX - Metric.costTextToLinePadding,
+            y: baseY - costHeight * (willDisplayCost / maxCost) * CGFloat(costStandards.count),
             width: costWidth,
             height: costHeight
         )
@@ -136,7 +149,8 @@ final class BarBackgroundLayer: CAShapeLayer {
         let costTextLayer = BarTextLayer(
             rect: costTextFrame,
             text: Int(willDisplayCost).numberFormatter(),
-            textFontSize: Metric.costFontSize
+            textFontSize: Metric.costFontSize,
+            alignment: .right
         )
         addSublayer(costTextLayer)
     }
@@ -148,6 +162,8 @@ extension BarBackgroundLayer {
     enum Metric {
         static let dividerCount = 5
         static let lineWidth: CGFloat = 2
+        
+        static let costTextToLinePadding: CGFloat = 2
         
         static let dateFontSize: CGFloat = 11
         static let costFontSize: CGFloat = 9

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
@@ -97,6 +97,8 @@ final class BarBackgroundLayer: CAShapeLayer {
     
     /// 배경의 하단에 차트 데이터 값이 존재하는 날짜를 표시한다.
     private func configureDateTextLayer(with index: Int) {
+        guard let willDisplayDate = criteria[safeIndex: index] else { return }
+        
         let textWidth = (rect.width - inset.width) / CGFloat(criteria.count)
         let textHeight = inset.height
         let baseX = rect.minX + inset.width
@@ -110,13 +112,15 @@ final class BarBackgroundLayer: CAShapeLayer {
         
         let dateTextLayer = BarTextLayer(
             rect: dateTextFrame,
-            text: Date.yearMonthDaySplitDashDateFormatter.string(from: criteria[index])
+            text: Date.yearMonthDaySplitDashDateFormatter.string(from: willDisplayDate)
         )
         addSublayer(dateTextLayer)
     }
     
     /// 배경의 좌측에 최고 금액을 기준으로 나눈 금액 단위를 표시한다.
     private func configureCostTextLayer(with index: Int) {
+        guard let willDisplayCost = costStandards[safeIndex: index] else { return }
+        
         let costWidth = inset.width
         let costHeight = (rect.height - inset.height) / CGFloat(costStandards.count + 1)
         let baseY = rect.maxY - inset.height
@@ -130,7 +134,7 @@ final class BarBackgroundLayer: CAShapeLayer {
         
         let costTextLayer = BarTextLayer(
             rect: costTextFrame,
-            text: Int(costStandards[index]).numberFormatter(),
+            text: Int(willDisplayCost).numberFormatter(),
             textFontSize: 9
         )
         addSublayer(costTextLayer)

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarBackgroundLayer.swift
@@ -112,7 +112,8 @@ final class BarBackgroundLayer: CAShapeLayer {
         
         let dateTextLayer = BarTextLayer(
             rect: dateTextFrame,
-            text: Date.yearMonthDaySplitDashDateFormatter.string(from: willDisplayDate)
+            text: Date.monthDayDateFormatter.string(from: willDisplayDate),
+            textFontSize: Metric.dateFontSize
         )
         addSublayer(dateTextLayer)
     }
@@ -135,7 +136,7 @@ final class BarBackgroundLayer: CAShapeLayer {
         let costTextLayer = BarTextLayer(
             rect: costTextFrame,
             text: Int(willDisplayCost).numberFormatter(),
-            textFontSize: 9
+            textFontSize: Metric.costFontSize
         )
         addSublayer(costTextLayer)
     }
@@ -147,6 +148,8 @@ extension BarBackgroundLayer {
     enum Metric {
         static let dividerCount = 5
         static let lineWidth: CGFloat = 2
-        static let textFontSize: CGFloat = 14
+        
+        static let dateFontSize: CGFloat = 11
+        static let costFontSize: CGFloat = 9
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
@@ -54,6 +54,7 @@ final class BarTextLayer: CATextLayer {
         )
         string = attributedString
         alignmentMode = .center
+        truncationMode = .end
     }
 }
 

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
@@ -15,14 +15,17 @@ final class BarTextLayer: CATextLayer {
     
     private let text: String
     
-    private let textFontSize: CGFloat?
+    private let textFontSize: CGFloat
+    
+    private let alignment: CATextLayerAlignmentMode?
     
     // MARK: - Init
     
-    init(rect: CGRect, text: String, textFontSize: CGFloat? = nil) {
+    init(rect: CGRect, text: String, textFontSize: CGFloat, alignment: CATextLayerAlignmentMode? = nil) {
         self.rect = rect
         self.text = text
         self.textFontSize = textFontSize
+        self.alignment = alignment
         
         super.init()
         
@@ -48,20 +51,12 @@ final class BarTextLayer: CATextLayer {
         let attributedString = NSAttributedString(
             string: text,
             attributes: [
-                .font: UIFont.boldSystemFont(ofSize: textFontSize ?? Metric.textFontSize),
+                .font: UIFont.boldSystemFont(ofSize: textFontSize),
                 .foregroundColor: UIColor.grey3 ?? UIColor()
             ]
         )
         string = attributedString
-        alignmentMode = .center
+        alignmentMode = alignment ?? .center
         truncationMode = .end
-    }
-}
-
-// MARK: - Namespaces
-
-extension BarTextLayer {
-    enum Metric {
-        static let textFontSize: CGFloat = 14
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/CustomBarChart.swift
@@ -59,6 +59,9 @@ final class CustomBarChart: UIView {
     /// 주어진 rect에 맞게 막대 차트를 그린다. 막대 차트는 영역에 꽉 채워서 그려진다.
     /// - Parameter rect: 막대 차트를 그릴 영역.
     override func draw(_ rect: CGRect) {
+        // 기존에 추가한 서브레이어를 모두 지운다.
+        removeAllSubLayers()
+        
         // 차트 배경 그리기
         let criteria = items.map { $0.criterion }
         let backgroundLayer = BarBackgroundLayer(
@@ -118,10 +121,8 @@ final class CustomBarChart: UIView {
     
     // MARK: - Animation Functions
     
-    /// 외부의 값 변화로 인해 애니메이션을 재실행할 경우 활용할 수 있는 메서드.
-    /// 이전에 등록된 서브레이어들을 모두 제거한 후 화면을 다시 그린다.
+    /// 외부의 값 변화로 인해 애니메이션을 재실행할 경우 활용할 수 있는 메서드. 화면을 다시 그린다.
     func executeAnimation() {
-        removeAllSubLayers()
         setNeedsDisplay()
     }
     

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -36,9 +36,17 @@ final class CustomPieChart: UIView {
     
     private var currentIndex = 0
     
-    private var currentItem: CustomChartItem<ExpenseType> { items[currentIndex] }
+    private var currentItem: CustomChartItem<ExpenseType>? {
+        items[safeIndex: currentIndex]
+    }
     
-    private var ratio: CGFloat { currentItem.value / total }
+    private var ratio: CGFloat {
+        guard total != 0,
+              let currentItem = currentItem
+        else { return 0 }
+        
+        return currentItem.value / total
+    }
     
     // MARK: - Init
     
@@ -83,7 +91,9 @@ final class CustomPieChart: UIView {
 
     }
     
-    private func drawOnePiece(with item: CustomChartItem<ExpenseType>, on rect: CGRect) {
+    private func drawOnePiece(with item: CustomChartItem<ExpenseType>?, on rect: CGRect) {
+        guard let item = item else { return }
+        
         let category = item.criterion
         let pieceLayer = PieceShapeLayer(
             center: center,

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/PieceTextLayer.swift
@@ -87,7 +87,7 @@ extension PieceTextLayer {
     enum Metric {
         static let radiusRatio: CGFloat = 0.4
 
-        static let textWidth: CGFloat = 60
+        static let textWidth: CGFloat = 70
         static let textFontSize: CGFloat = 16
         
         static let positionRatio: CGFloat = 0.7


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 파이차트 및 막대차트의 크래시 위험성을 제거했습니다.
- 막대차트에 safe index를 미처 적용하지 못한 부분이 있음을 발견해 이를 적용했습니다.
- 차트의 텍스트가 일부 잘려 보이는 현상을 수정했습니다.
- 막대 차트의 좌측에 표시되는 금액 단위를 올림처리하여 표시하도록 수정했습니다.
  - 지출 최댓값이 1234원이라면, 0 ~ 1300 범위를 5등분하여 [260, 520, 780, 1040]이 표시됩니다.

## 관련 이슈
- resolves #160 
- resolves #157 

## 리뷰노트
> 고민, 과정, 궁금한점
- 선경님이 알려주신 버그를 재연해보려 했지만 실패했습니다..😢 하지만 이전에 같은 현상이 나타났던 적이 있었는데, 기존에 이미 막대차트 뷰의 서브레이어들이 깔려 있는 상태에서 다시 중복되는 서브레이어들과 애니메이션이 추가되었을 때 발생하는 문제였습니다. 
- executeAnimation이 실행될 때 외에도 화면이 다시 그려질 가능성이 있다고 생각해서 removeAllSubLayers 메서드를 draw 내부로 이동시켜 화면이 다시 그려질 때는 반드시 기존 서브레이어들을 삭제하도록 했습니다.
- 하지만 이렇게 해도 같은 문제가 생긴다면... 다시 원인을 찾아봐야할 것 같습니다..🥲


## 스크린샷

<img src="https://user-images.githubusercontent.com/50136980/207103112-9b8cf668-b2fc-4247-9520-a606ef07323c.png" width="33%">
