### PR TITLE
[얼굴 인식] 블러 처리 버그 해결 및 기능 개선 #155

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A499EB4F294709B400E7F774 /* DiaryEditViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499EB4E294709B400E7F774 /* DiaryEditViewModelDelegate.swift */; };
 		A499EB5129470BE300E7F774 /* DiaryEditRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499EB5029470BE300E7F774 /* DiaryEditRepository.swift */; };
 		A499EB5429470BF800E7F774 /* DiaryEditLocalRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499EB5329470BF800E7F774 /* DiaryEditLocalRepository.swift */; };
+		A499EB5629476C2F00E7F774 /* UIImage+Downsample.swift in Sources */ = {isa = PBXBuildFile; fileRef = A499EB5529476C2F00E7F774 /* UIImage+Downsample.swift */; };
 		A49FD4662934DF7D00A92427 /* TranslucentActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49FD4652934DF7D00A92427 /* TranslucentActivityIndicatorView.swift */; };
 		A4B38C3029407D1500E52150 /* PlanAddViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B38C2F29407D1500E52150 /* PlanAddViewControllerDelegate.swift */; };
 		A4B38C322940C73C00E52150 /* PlanListViewModelDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B38C312940C73C00E52150 /* PlanListViewModelDelegate.swift */; };
@@ -248,6 +249,7 @@
 		A499EB4E294709B400E7F774 /* DiaryEditViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditViewModelDelegate.swift; sourceTree = "<group>"; };
 		A499EB5029470BE300E7F774 /* DiaryEditRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditRepository.swift; sourceTree = "<group>"; };
 		A499EB5329470BF800E7F774 /* DiaryEditLocalRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryEditLocalRepository.swift; sourceTree = "<group>"; };
+		A499EB5529476C2F00E7F774 /* UIImage+Downsample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Downsample.swift"; sourceTree = "<group>"; };
 		A49FD4652934DF7D00A92427 /* TranslucentActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslucentActivityIndicatorView.swift; sourceTree = "<group>"; };
 		A4B38C2F29407D1500E52150 /* PlanAddViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanAddViewControllerDelegate.swift; sourceTree = "<group>"; };
 		A4B38C312940C73C00E52150 /* PlanListViewModelDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanListViewModelDelegate.swift; sourceTree = "<group>"; };
@@ -1226,6 +1228,7 @@
 			children = (
 				BBEEFA8929376BC8005DEF38 /* UIImage+.swift */,
 				A44B8748294361F900C55B3A /* UIImage+SystemImages.swift */,
+				A499EB5529476C2F00E7F774 /* UIImage+Downsample.swift */,
 			);
 			path = UIImage;
 			sourceTree = "<group>";
@@ -1911,7 +1914,6 @@
 				BB6BE55D29360A2F00857D25 /* DetectedFaceCell.swift in Sources */,
 				EE97A8B62940638800BB8390 /* PlanAddView.swift in Sources */,
 				A499EB492947096800E7F774 /* DiaryEditViewController.swift in Sources */,
-				BBB31A392925F77900C9E3A9 /* ExpenseTravelListCell.swift in Sources */,
 				B57D962E2922318F00B510B8 /* ExpenseDTO.swift in Sources */,
 				A48E994A292531B30029D57D /* UIViewController+SetRightBarPlusButton.swift in Sources */,
 				BB4630C22946E7B100FB106F /* ExpenseTravelCollectionViewCell.swift in Sources */,
@@ -1920,6 +1922,7 @@
 				A499EB4C2947099700E7F774 /* DiaryEditViewModel.swift in Sources */,
 				BB7D9A262926088A00BF2BD6 /* ExpensePlaceholdView.swift in Sources */,
 				BB02B094292F29E000FE11DA /* DiaryListViewModelProtocol.swift in Sources */,
+				A499EB5629476C2F00E7F774 /* UIImage+Downsample.swift in Sources */,
 				BBFAC089291CBDD700D7FD57 /* SceneDelegate.swift in Sources */,
 				EE85FBC3292BA9B600FF0C7C /* ExpenseAddViewController.swift in Sources */,
 				A4EB25C9292C92CC002D129A /* DiaryAddViewModelDelegate.swift in Sources */,

--- a/Doesaegim/Doesaegim/Data/ViewModel/DetectInfoViewModel.swift
+++ b/Doesaegim/Doesaegim/Data/ViewModel/DetectInfoViewModel.swift
@@ -14,12 +14,14 @@ struct DetectInfoViewModel: Hashable {
     var image: UIImage // 선택된 부분의 이미지
     var bound: CGRect
     var isSelected: Bool
+    var downsampledBounds: CGRect
     
-    init(uuid: UUID, image: UIImage, bound: CGRect) {
+    init(uuid: UUID, image: UIImage, bound: CGRect, downsampledBounds: CGRect) {
         self.uuid = uuid
         self.image = image
         self.bound = bound
         self.isSelected = false
+        self.downsampledBounds = downsampledBounds
     }
     
     func hash(into hasher: inout Hasher) {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryDetail/View/DiaryDetailViewController.swift
@@ -103,7 +103,13 @@ final class DiaryDetailViewController: UIViewController {
             image: .edit,
             primaryAction: UIAction(handler: { [weak self] _ in
                 guard let diary = self?.viewModel.diary,
-                      let images = self?.viewModel.cellViewModels.map({ UIImage(data: $0.data) })
+                      let size = self?.view.bounds.size,
+                      let scale = self?.view.window?.windowScene?.screen.scale,
+                      let images = self?.viewModel.cellViewModels.map({ UIImage(
+                        data: $0.data,
+                        size: size,
+                        scale: scale
+                      )})
                 else {
                     return
                 }
@@ -130,8 +136,15 @@ final class DiaryDetailViewController: UIViewController {
     
     /// 이미지 슬라이더 컬렉션뷰의 데이터소스를 지정한다.
     private func configureImageSliderDataSource() {
-        let cellRegistration = CellRegistration { cell, _, itemIdentifier in
-            let image = UIImage(data: itemIdentifier.data)
+        let cellRegistration = CellRegistration { [weak self] cell, _, itemIdentifier in
+            guard let size = self?.view.bounds.size,
+                  let scale = self?.view.window?.windowScene?.screen.scale
+            else {
+                cell.setupImage(image: UIImage(data: itemIdentifier.data))
+                return 
+            }
+
+            let image = UIImage(data: itemIdentifier.data, size: size, scale: scale)
             cell.setupImage(image: image)
         }
         
@@ -202,7 +215,7 @@ extension DiaryDetailViewController: UICollectionViewDelegate {
             return
         }
         
-        let photoDetailViewController = DiaryPhotoDetailViewController(item: item)
+        let photoDetailViewController = DiaryPhotoDetailViewController(imageData: item.data)
         navigationController?.pushViewController(photoDetailViewController, animated: true)
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryPhotoDetail/DiaryPhotoDetailViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryPhotoDetail/DiaryPhotoDetailViewController.swift
@@ -23,12 +23,13 @@ final class DiaryPhotoDetailViewController: UIViewController {
     
     // MARK: - Properties
     
-    private let item: DetailImageCellViewModel
+    private let imageData: Data
+
     
     // MARK: - Lifecycles
     
-    init(item: DetailImageCellViewModel) {
-        self.item = item
+    init(imageData: Data) {
+        self.imageData = imageData
         super.init(nibName: nil, bundle: nil)
 
         hidesBottomBarWhenPushed = true
@@ -83,9 +84,8 @@ final class DiaryPhotoDetailViewController: UIViewController {
         
         let mosaicToShare = UIAction(
             title: "모자이크 후 공유하기") { [weak self] _ in
-                guard let self,
-                      let image = self.photoImageView.image else { return }
-                let controller = FaceDetectController(image: image, viewModel: FaceDetectViewModel())
+                guard let self else { return }
+                let controller = FaceDetectController(data: self.imageData, viewModel: FaceDetectViewModel())
                 self.navigationController?.pushViewController(controller, animated: true)
             }
         let sharedToActivityViewController = UIAction(
@@ -109,6 +109,13 @@ final class DiaryPhotoDetailViewController: UIViewController {
     }
     
     private func configurePhotoImageView() {
-        photoImageView.image = UIImage(data: item.data)
+        guard let scale = view.window?.windowScene?.screen.scale
+        else {
+            photoImageView.image = UIImage(data: imageData)
+            return
+        }
+
+        let size = view.safeAreaLayoutGuide.layoutFrame.size
+        photoImageView.image = UIImage(data: imageData, size: size, scale: scale)
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/FaceDetectViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/FaceDetectViewModelProtocol.swift
@@ -18,8 +18,7 @@ protocol FaceDetectViewModelProtocol: AnyObject {
     
     func performVisionRequest(image: CGImage, orientation: CGImagePropertyOrientation)
     func cropImage(of image: UIImage?, with cropRect: CGRect) -> UIImage?
-    func addDetectInfo(with image: UIImage?, boundingBox: CGRect)
-    
+    func addDetectInfo(with image: UIImage?, downsampledImage: UIImage?, boundingBox: CGRect)
 }
 
 protocol FaceDetectViewModeleDelegate: AnyObject {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/BlurredImageViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/BlurredImageViewController.swift
@@ -22,6 +22,8 @@ final class BlurredImageViewController: UIViewController {
         return imageView
     }()
 
+    private let activityIndicator = UIActivityIndicatorView()
+
 
     // MARK: - Properties
 
@@ -58,16 +60,22 @@ final class BlurredImageViewController: UIViewController {
 
     private func configureViews() {
         view.backgroundColor = .white
-        configureImageView()
+        configureSubviews()
     }
 
-    private func configureImageView() {
-        view.addSubview(imageView)
-        imageView.snp.makeConstraints { $0.edges.equalTo(view.safeAreaLayoutGuide) }
+    private func configureSubviews() {
+        view.addSubviews(imageView, activityIndicator)
+        [imageView, activityIndicator].forEach { subview in
+            subview.snp.makeConstraints { $0.edges.equalTo(view.safeAreaLayoutGuide) }
+        }
+        activityIndicator.startAnimating()
     }
 
     private func bindToViewModel() {
-        viewModel.blurCompletionHandler = { [weak self] in self?.imageView.image = $0 }
+        viewModel.blurCompletionHandler = { [weak self] in
+            self?.imageView.image = $0
+            self?.activityIndicator.stopAnimating()
+        }
     }
 
     private func configureNavigationBar() {

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
@@ -31,19 +31,37 @@ final class BlurredImageViewModel {
     // MARK: Functions
 
     func applyFilter() {
-        guard let ciImage = CIImage(image: image),
-              let blurredImage = ciImage.gaussianBlur(),
-              let maskImage = ciImage.maskAreas(selectedFaceRects),
-              let blendedImage = ciImage.blendWithMask(maskImage, inputImage: blurredImage),
-              let cgImage = BlurredImageViewModel.context.createCGImage(
-                blendedImage,
-                from: blendedImage.extent
-              )
-        else {
-            blurCompletionHandler?(image)
-            return
-        }
+        DispatchQueue.global(qos: .userInteractive).async { [weak self] in
+            guard let image = self?.image,
+                  let ciImage = CIImage(image: image),
+                  let blurredImage = ciImage.gaussianBlur(),
+                  let selectedFaceRects = self?.selectedFaceRects,
+                  let maskImage = ciImage.maskAreas(selectedFaceRects),
+                  let blendedImage = ciImage.blendWithMask(maskImage, inputImage: blurredImage),
+                  let cgImage = BlurredImageViewModel.context.createCGImage(
+                    blendedImage,
+                    from: blendedImage.extent
+                  )
+            else {
+                DispatchQueue.main.async { [weak self] in
+                    let errorImage = UIImage(systemName: StringLiteral.errorImageName)
+                    self?.blurCompletionHandler?(self?.image ?? errorImage)
+                }
+                return
+            }
 
-        blurCompletionHandler?(UIImage(cgImage: cgImage))
+            DispatchQueue.main.async { [weak self] in
+                self?.blurCompletionHandler?(UIImage(cgImage: cgImage))
+            }
+        }
+    }
+}
+
+
+// MARK: - Constants
+fileprivate extension BlurredImageViewModel {
+
+    enum StringLiteral {
+        static let errorImageName = "questionmark.circle"
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
@@ -40,7 +40,7 @@ final class BlurredImageViewModel {
                 from: blendedImage.extent
               )
         else {
-            blurCompletionHandler?(nil)
+            blurCompletionHandler?(image)
             return
         }
 

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/FaceDetectViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/FaceDetectViewModel.swift
@@ -66,19 +66,31 @@ extension FaceDetectViewModel {
         }
     }
     
-    func addDetectInfo(with image: UIImage?, boundingBox: CGRect) {
-        guard let image = image else { return }
+    func addDetectInfo(with image: UIImage?, downsampledImage: UIImage?, boundingBox: CGRect) {
+        guard let image = image,
+              let downsampledImage
+        else { return }
+
+        let rect = calculateBounds(with: image, boundingBox: boundingBox)
+        let downsampledRect = calculateBounds(with: downsampledImage, boundingBox: boundingBox)
         
+        guard let croppedImage = cropImage(of: image, with: rect) else { return }
+        let newDetectInfo = DetectInfoViewModel(
+            uuid: UUID(),
+            image: croppedImage,
+            bound: rect,
+            downsampledBounds: downsampledRect
+        )
+        detectInfos.append(newDetectInfo)
+    }
+
+    private func calculateBounds(with image: UIImage, boundingBox: CGRect) -> CGRect {
         let width = image.size.width * boundingBox.size.width
         let height = image.size.height * boundingBox.size.height
         let xCoordinate = image.size.width * boundingBox.origin.x
         let yCoordinate = (image.size.height * (1 - boundingBox.origin.y)) - height
 
-        let rect = CGRect(x: xCoordinate, y: yCoordinate, width: width, height: height)
-        
-        guard let croppedImage = cropImage(of: image, with: rect) else { return }
-        let newDetectInfo = DetectInfoViewModel(uuid: UUID(), image: croppedImage, bound: rect)
-        detectInfos.append(newDetectInfo)
+        return CGRect(x: xCoordinate, y: yCoordinate, width: width, height: height)
     }
     
     func cropImage(of image: UIImage?, with cropRect: CGRect) -> UIImage? {

--- a/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+Downsample.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UIImage/UIImage+Downsample.swift
@@ -1,0 +1,58 @@
+//
+//  UIImage+Downsample.swift
+//  Doesaegim
+//
+//  Created by sun on 2022/12/12.
+//
+
+import UIKit
+
+extension UIImage {
+
+    enum DownsampleMode {
+        case aspectFit
+        case aspectFill
+    }
+
+
+    /// 다운샘플링된 이미지를 생성, 실패 시 nil 리턴
+    /// - Parameters:
+    ///   - data: 이미지 데이터
+    ///   - size: 다운샘플링할 크기
+    convenience init?(data: Data, size: CGSize, scale: CGFloat, mode: DownsampleMode = .aspectFill) {
+        let options = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithData(data as CFData, options),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, .zero, options) as? [CFString: Any],
+              let pixelWidth = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+              let pixelHeight = properties[kCGImagePropertyPixelHeight] as? CGFloat,
+              pixelWidth > .zero,
+              pixelHeight > .zero
+        else {
+            return nil
+        }
+
+        var maxPixelSize = max(size.width, size.height) * scale
+        if mode == .aspectFill {
+            let heightWidthRatio = pixelHeight / pixelWidth
+            let smallSide = min(size.width, size.height)
+            let hasLongerHeight = heightWidthRatio > 1
+            let width = hasLongerHeight ? smallSide : smallSide / heightWidthRatio
+            let height = hasLongerHeight ? smallSide * heightWidthRatio : smallSide
+            maxPixelSize = max(width, height) * scale
+        }
+
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ] as CFDictionary
+
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, .zero, thumbnailOptions)
+        else {
+            return nil
+        }
+
+        self.init(cgImage: cgImage)
+    }
+}


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- #155

- 블러처리할 얼굴을 선택하지 않는 경우 사진이 뜨지 않는 버그를 해결했습니다. 
- 처리할 얼굴의 개수가 증가할 때 이미지 크기가 클수록 시간이 오래 걸리는 문제를 해결하기 위해 다운샘플링을 구현했습니다. 
  - 다이어리 디테일 화면부터 다운샘플링을 적용하면 메모리 절약 효과가 클 것 같아 디테일 화면에서부터 쭉 적용했습니다. 디테일 화면 기준 약 50%가량 절약되는 것 같습니다. 
  - 얼굴인식 화면의 경우 다운샘플링에 따른 화질 저하로 얼굴 인식률이 줄어드는 문제가 있어 적용하지 않았습니다. 
  - 블로그...정리해서 빨리...공유하겠습니다...
## 리뷰노트
> 고민, 과정, 궁금한점

## 스크린샷

https://user-images.githubusercontent.com/81314063/207130305-7d74c494-3447-4302-875c-0cc852c3e784.MP4

