### PR TITLE
[지출 목록] 지출 셀, 헤더 디자인, 삭제기능 추가

### DIFF
--- a/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
+++ b/Doesaegim/Doesaegim.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		BB4630D3294772E100FB106F /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4630D2294772E100FB106F /* UserDefaults+.swift */; };
 		BB5771A42923A08F0034047D /* ExpenseTravelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */; };
 		BB5771AC2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */; };
+		BB59484329481B0C002EFA83 /* UICollectionViewCell+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB59484229481B0C002EFA83 /* UICollectionViewCell+Shadow.swift */; };
 		BB5DE44C292B8E86001DA6F6 /* Int+convertCostString.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5DE44B292B8E86001DA6F6 /* Int+convertCostString.swift */; };
 		BB6079B1292F3ECF00BF30C8 /* DiaryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6079B0292F3ECF00BF30C8 /* DiaryListCell.swift */; };
 		BB6079B3292F546900BF30C8 /* DiaryListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6079B2292F546900BF30C8 /* DiaryListHeaderView.swift */; };
@@ -361,6 +362,7 @@
 		BB4630D2294772E100FB106F /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		BB5771A32923A08F0034047D /* ExpenseTravelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModel.swift; sourceTree = "<group>"; };
 		BB5771AB2923C4DE0034047D /* ExpenseTravelViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTravelViewModelProtocol.swift; sourceTree = "<group>"; };
+		BB59484229481B0C002EFA83 /* UICollectionViewCell+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Shadow.swift"; sourceTree = "<group>"; };
 		BB5DE44B292B8E86001DA6F6 /* Int+convertCostString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+convertCostString.swift"; sourceTree = "<group>"; };
 		BB6079B0292F3ECF00BF30C8 /* DiaryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCell.swift; sourceTree = "<group>"; };
 		BB6079B2292F546900BF30C8 /* DiaryListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListHeaderView.swift; sourceTree = "<group>"; };
@@ -1204,6 +1206,7 @@
 				A4B82D8B2938B6F200347B71 /* CIImage+Filters.swift */,
 				A4B82DD3293D7F2100347B71 /* Array+SafeIndex.swift */,
 				BB4630D2294772E100FB106F /* UserDefaults+.swift */,
+				BB59484229481B0C002EFA83 /* UICollectionViewCell+Shadow.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1780,6 +1783,7 @@
 				B5C421A4292F204900963B17 /* ExpenseAddPickerViewController.swift in Sources */,
 				BB22446C2941CE4900546E19 /* CalendarSettingViewModel.swift in Sources */,
 				B5C421A3292F201700963B17 /* ExpenseAddPickerViewProtocol.swift in Sources */,
+				BB59484329481B0C002EFA83 /* UICollectionViewCell+Shadow.swift in Sources */,
 				EEA1C826292F4E6000B80901 /* ExchangeMemoryCache.swift in Sources */,
 				A44B8749294361FA00C55B3A /* UIImage+SystemImages.swift in Sources */,
 				B57D9630292231FC00B510B8 /* DiaryDTO.swift in Sources */,

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/DiaryList/View/DiaryListCell.swift
@@ -154,13 +154,4 @@ extension DiaryListCell {
         }
     }
     
-    // MARK: - Functions
-    private func addShadow() {
-        layer.masksToBounds = false
-        layer.shadowColor = UIColor.grey2?.cgColor
-        layer.shadowOffset = CGSize(width: 1, height: 1)
-        layer.shadowRadius = 3
-        layer.shadowOpacity = 1
-
-    }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ExpenseListViewModelProtocol.swift
@@ -17,6 +17,7 @@ protocol ExpenseListViewModelProtocol: AnyObject {
     func fetchCurrentTravel(with travelID: UUID?)
     func fetchExpenseData()
     func addExpenseData() // 추후 제거
+    func deleteExpenseData(with id: UUID)
     
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseCollectionHeaderView.swift
@@ -36,6 +36,7 @@ final class ExpenseCollectionHeaderView: UICollectionReusableView {
     private let contentStack: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.spacing = 6
         
         return stackView
     }()

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ExpenseListCell: UICollectionViewListCell {
+final class ExpenseListCell: UICollectionViewCell {
     
     static let identifier: String = String(describing: ExpenseListCell.self)
     
@@ -16,7 +16,7 @@ final class ExpenseListCell: UICollectionViewListCell {
     let categoryImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(systemName: "dollarsign.circle")
-        imageView.tintColor = .grey3
+        imageView.tintColor = .primaryOrange
         return imageView
     }()
     
@@ -37,7 +37,7 @@ final class ExpenseListCell: UICollectionViewListCell {
         label.font = label.font.withSize(16)
         label.textColor = .black
         label.lineBreakMode = .byTruncatingTail
-        label.numberOfLines = 1
+        label.numberOfLines = 2
         
         return label
     }()
@@ -48,7 +48,7 @@ final class ExpenseListCell: UICollectionViewListCell {
         label.font = label.font.withSize(12)
         label.textColor = .grey4
         label.lineBreakMode = .byTruncatingTail
-        label.numberOfLines = 1
+        label.numberOfLines = 10
         
         return label
     }()
@@ -62,6 +62,12 @@ final class ExpenseListCell: UICollectionViewListCell {
         
         return label
 
+    }()
+    
+    let menuButton: UIButton = {
+        
+        
+        
     }()
     
     // MARK: - Initializer
@@ -85,9 +91,15 @@ final class ExpenseListCell: UICollectionViewListCell {
     // MARK: - Configuration
     
     private func configure() {
-        backgroundColor = .white
+        configureView()
         configureSubviews()
         configureConstraints()
+    }
+    
+    private func configureView() {
+        backgroundColor = .systemBackground
+        layer.cornerRadius = 10
+        addShadow()
     }
     
     private func configureSubviews() {
@@ -103,7 +115,7 @@ final class ExpenseListCell: UICollectionViewListCell {
     private func configureConstraints() {
         
         categoryImageView.snp.makeConstraints {
-            $0.leading.equalToSuperview()
+            $0.leading.equalToSuperview().inset(9)
             $0.centerY.equalToSuperview()
             $0.width.equalTo(30)
             $0.height.equalTo(30)
@@ -115,9 +127,9 @@ final class ExpenseListCell: UICollectionViewListCell {
         }
         
         labelStackView.snp.makeConstraints {
-            $0.leading.equalTo(categoryImageView.snp.trailing).offset(6)
-            $0.trailing.equalTo(priceLabel.snp.leading).offset(-3)
-            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(categoryImageView.snp.trailing).offset(9)
+            $0.trailing.equalTo(priceLabel.snp.leading).offset(-6)
+            $0.verticalEdges.equalToSuperview().inset(6)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -73,6 +73,8 @@ final class ExpenseListCell: UICollectionViewCell {
         return button
     }()
     
+    var deleteAction: (() -> Void)?
+    
     // MARK: - Initializer
     
     override init(frame: CGRect) {
@@ -143,15 +145,15 @@ final class ExpenseListCell: UICollectionViewCell {
 //        }
     }
     
-    func configureContent(with data: ExpenseInfoViewModel, handler: @escaping () -> Void) {
+    func configureContent(with data: ExpenseInfoViewModel) {
         
         configureImageView(with: data.category)
         configureTitle(with: data.name)
         configureDescription(with: data.content)
         configurePrice(with: data.cost)
         
-        deleteButton.addAction(UIAction(handler: { _ in
-            handler()
+        deleteButton.addAction(UIAction(handler: { [weak self] _ in
+            self?.deleteAction?()
         }), for: .touchUpInside)
         
     }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListCell.swift
@@ -25,7 +25,7 @@ final class ExpenseListCell: UICollectionViewCell {
         
         stackView.axis = .vertical
         stackView.distribution = .fill
-        stackView.spacing = 3
+        stackView.spacing = 4
         stackView.alignment = .leading
         
         return stackView
@@ -64,10 +64,13 @@ final class ExpenseListCell: UICollectionViewCell {
 
     }()
     
-    let menuButton: UIButton = {
+    let deleteButton: UIButton = {
+        let button = UIButton()
         
+        button.setImage(UIImage(systemName: "trash"), for: .normal)
+        button.tintColor = .primaryOrange
         
-        
+        return button
     }()
     
     // MARK: - Initializer
@@ -110,6 +113,7 @@ final class ExpenseListCell: UICollectionViewCell {
         // stack view
         labelStackView.addArrangedSubview(expenseTitle)
         labelStackView.addArrangedSubview(expenseDescription)
+        labelStackView.addArrangedSubview(deleteButton)
     }
     
     private func configureConstraints() {
@@ -121,24 +125,34 @@ final class ExpenseListCell: UICollectionViewCell {
             $0.height.equalTo(30)
         }
         
-        priceLabel.snp.makeConstraints {
-            $0.centerY.equalTo(self.snp.centerY)
-            $0.trailing.equalTo(self.snp.trailing).offset(-12)
-        }
-        
         labelStackView.snp.makeConstraints {
             $0.leading.equalTo(categoryImageView.snp.trailing).offset(9)
             $0.trailing.equalTo(priceLabel.snp.leading).offset(-6)
             $0.verticalEdges.equalToSuperview().inset(6)
         }
+        
+        priceLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(9)
+        }
+        
+//        menuButton.snp.makeConstraints {
+//            $0.leading.equalTo(priceLabel.snp.trailing).offset(6)
+//            $0.trailing.equalToSuperview().inset(9)
+//            $0.centerY.equalToSuperview()
+//        }
     }
     
-    func configureContent(with data: ExpenseInfoViewModel) {
+    func configureContent(with data: ExpenseInfoViewModel, handler: @escaping () -> Void) {
         
         configureImageView(with: data.category)
         configureTitle(with: data.name)
         configureDescription(with: data.content)
         configurePrice(with: data.cost)
+        
+        deleteButton.addAction(UIAction(handler: { _ in
+            handler()
+        }), for: .touchUpInside)
         
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -83,7 +83,7 @@ final class ExpenseListViewController: UIViewController {
     
     private func configureConstraints() {
         expenseCollectionView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
+            $0.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
             $0.verticalEdges.equalTo(view.safeAreaLayoutGuide)
         }
         
@@ -128,9 +128,9 @@ final class ExpenseListViewController: UIViewController {
             
             section.contentInsets = NSDirectionalEdgeInsets(
                 top: 0,
-                leading: 0,
+                leading: 16,
                 bottom: 6,
-                trailing: 0
+                trailing: 16
             )
             
             let sectionHeaderSize = NSCollectionLayoutSize(
@@ -156,6 +156,13 @@ final class ExpenseListViewController: UIViewController {
             layoutSize: globalHeaderSize,
             elementKind: HeaderKind.globalHeader,
             alignment: .top
+        )
+        
+        globalHeader.contentInsets = NSDirectionalEdgeInsets(
+            top: 0,
+            leading: 16,
+            bottom: 6,
+            trailing: 16
         )
         
         let configuration = UICollectionViewCompositionalLayoutConfiguration()

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -124,6 +124,13 @@ final class ExpenseListViewController: UIViewController {
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             
+            group.edgeSpacing = NSCollectionLayoutEdgeSpacing(
+                leading: .fixed(0),
+                top: .fixed(6),
+                trailing: .fixed(0),
+                bottom: .fixed(6)
+            )
+            
             let section = NSCollectionLayoutSection(group: group)
             
             let sectionHeaderSize = NSCollectionLayoutSize(

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -124,14 +124,14 @@ final class ExpenseListViewController: UIViewController {
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             
-            group.edgeSpacing = NSCollectionLayoutEdgeSpacing(
-                leading: .fixed(0),
-                top: .fixed(6),
-                trailing: .fixed(0),
-                bottom: .fixed(6)
-            )
-            
             let section = NSCollectionLayoutSection(group: group)
+            
+            section.contentInsets = NSDirectionalEdgeInsets(
+                top: 0,
+                leading: 0,
+                bottom: 6,
+                trailing: 0
+            )
             
             let sectionHeaderSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -181,7 +181,20 @@ final class ExpenseListViewController: UIViewController {
         
         var sections: [String]?
         let expenseCell = CellRegistration { cell, _, identifier in
-            cell.configureContent(with: identifier)
+            cell.configureContent(with: identifier) { [weak self] in
+                // 알림을 내보내고, 지우는 로직
+                let cancelAction = UIAlertAction(title: "취소", style: .default)
+                let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
+                    self?.viewModel?.deleteExpenseData(with: identifier.uuid)
+                }
+                
+                self?.presentAlert(
+                    title: "지출을 삭제하시겠습니까?",
+                    message: "한번 삭제한 지출은 복구할 수 없습니다.",
+                    actions: cancelAction, deleteAction
+                )
+                
+            }
         }
         
         expenseDataSource = DataSource(

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -187,9 +187,11 @@ final class ExpenseListViewController: UIViewController {
     private func configureCollectionViewDataSource() {
         
         var sections: [String]?
-        let expenseCell = CellRegistration { cell, _, identifier in
-            cell.configureContent(with: identifier) { [weak self] in
-                // 알림을 내보내고, 지우는 로직
+        let expenseCell = CellRegistration { cell, indexPath, identifier in
+            
+            cell.configureContent(with: identifier)
+            cell.deleteAction = { [weak self] in
+                
                 let cancelAction = UIAlertAction(title: "취소", style: .default)
                 let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { [weak self] _ in
                     self?.viewModel?.deleteExpenseData(with: identifier.uuid)
@@ -200,8 +202,8 @@ final class ExpenseListViewController: UIViewController {
                     message: "한번 삭제한 지출은 복구할 수 없습니다.",
                     actions: cancelAction, deleteAction
                 )
-                
             }
+            
         }
         
         expenseDataSource = DataSource(
@@ -304,6 +306,7 @@ extension ExpenseListViewController: ExpenseListViewModelDelegate {
 extension ExpenseListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         print(indexPath)
+        
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -107,13 +107,20 @@ final class ExpenseListViewController: UIViewController {
         let layout = UICollectionViewCompositionalLayout { _, _ -> NSCollectionLayoutSection? in
             let itemSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(50)
+                heightDimension: .estimated(50)
             )
             let item = NSCollectionLayoutItem(layoutSize: itemSize)
             
+            item.edgeSpacing = NSCollectionLayoutEdgeSpacing(
+                leading: .fixed(0),
+                top: .fixed(6),
+                trailing: .fixed(0),
+                bottom: .fixed(6)
+            )
+            
             let groupSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(50)
+                heightDimension: .estimated(50)
             )
             let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
             

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseSectionHeaderView.swift
@@ -13,9 +13,10 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     
     let dateLabel: UILabel = {
         let label = UILabel()
-        label.font = label.font.withSize(18)
+        label.font = .boldSystemFont(ofSize: 18)
+        label.textColor = .white
         label.text = "날짜"
-        label.textColor = .black
+        
         
         return label
     }()
@@ -31,9 +32,15 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     }
     
     private func configure() {
-        backgroundColor = .white
+        configureView()
         configureSubviews()
         configureConstraints()
+    }
+    
+    private func configureView() {
+        
+        backgroundColor = .primaryOrange
+        layer.cornerRadius = 10
     }
     
     private func configureSubviews() {
@@ -42,8 +49,8 @@ final class ExpenseSectionHeaderView: UICollectionReusableView {
     
     private func configureConstraints() {
         dateLabel.snp.makeConstraints {
-            $0.centerY.equalTo(self.snp.centerY)
-            $0.leading.equalTo(self.snp.leading)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(6)
         }
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -94,6 +94,33 @@ extension ExpenseListViewModel {
         }
         
     }
+    
+    func deleteExpenseData(with id: UUID) {
+        
+        // data에 해당하는 지출 데이터를 지운다.
+        let result = PersistentRepository.shared.fetchExpense()
+        switch result {
+        case .success(let expenses):
+            let deleteExpense = expenses.filter { $0.id == id}
+            guard let deleteObject = deleteExpense.last,
+                  let travel = currentTravel else { return }
+            print("JH", deleteExpense)
+            let deleteResult = PersistentManager.shared.delete(deleteObject)
+            switch deleteResult {
+            case .success(let isDeleteComplete):
+                // 성공했다면 데이터를 다시 로드
+                if isDeleteComplete { fetchExpenseData() }
+            case .failure(let error):
+                // TODO: - 삭제 실패 에러처리
+                print(error.localizedDescription)
+            }
+            
+            
+        case .failure(let error):
+            print("EXPENSE FETCH 실패")
+            print(error.localizedDescription)
+        }
+    }
 }
 
 // MARK: - Utility Functions

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -101,7 +101,7 @@ extension ExpenseListViewModel {
         let result = PersistentRepository.shared.fetchExpense()
         switch result {
         case .success(let expenses):
-            let deleteExpense = expenses.filter { $0.id == id}
+            let deleteExpense = expenses.filter { $0.id == id }
             guard let deleteObject = deleteExpense.last,
                   let travel = currentTravel else { return }
             print("JH", deleteExpense)
@@ -134,7 +134,7 @@ extension ExpenseListViewModel {
             fatalError("ExpenseListViewModel - sortByDate date 정보를 받지 못했거나 dateFormatter에 이상이 있습니다.")
         }
         
-        return leftDateValue < rightDateValue
+        return leftDateValue > rightDateValue
     }
     
     private func sortByDateString(_ lhs: String, _ rhs: String) -> Bool {

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelCollectionViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseTravelList/View/ExpenseTravelCollectionViewCell.swift
@@ -127,13 +127,6 @@ extension ExpenseTravelCollectionViewCell {
         priceLabel.text = cost.numberFormatter()
     }
     
-    private func addShadow() {
-        layer.masksToBounds = false
-        layer.shadowColor = UIColor.grey2?.cgColor
-        layer.shadowOffset = CGSize(width: 1, height: 1)
-        layer.shadowRadius = 3
-        layer.shadowOpacity = 1
 
-    }
     
 }

--- a/Doesaegim/Doesaegim/Presentation/SettingScene/Library/View/LibraryCollectionViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/SettingScene/Library/View/LibraryCollectionViewCell.swift
@@ -119,12 +119,4 @@ extension LibraryCollectionViewCell {
         descriptionLabel.text = data.description
     }
     
-    private func addShadow() {
-        layer.masksToBounds = false
-        layer.shadowColor = UIColor.grey2?.cgColor
-        layer.shadowOffset = CGSize(width: 1, height: 1)
-        layer.shadowRadius = 2
-        layer.shadowOpacity = 1
-
-    }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelCollectionViewCell.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/TravelList/View/TravelCollectionViewCell.swift
@@ -110,13 +110,4 @@ extension TravelCollectionViewCell {
         dateLabel.text = Date.convertTravelString(start: data.startDate, end: data.endDate)
     }
     
-    private func addShadow() {
-        layer.masksToBounds = false
-        layer.shadowColor = UIColor.grey2?.cgColor
-        layer.shadowOffset = CGSize(width: 1, height: 1)
-        layer.shadowRadius = 3
-        layer.shadowOpacity = 1
-
-    }
-    
 }

--- a/Doesaegim/Doesaegim/Utility/Extensions/UICollectionViewCell+Shadow.swift
+++ b/Doesaegim/Doesaegim/Utility/Extensions/UICollectionViewCell+Shadow.swift
@@ -1,0 +1,22 @@
+//
+//  UICollectionViewCell+.swift
+//  Doesaegim
+//
+//  Created by Jaehoon So on 2022/12/13.
+//
+
+import UIKit
+
+
+extension UICollectionViewCell {
+    
+    public func addShadow() {
+        layer.masksToBounds = false
+        layer.shadowColor = UIColor.grey2?.cgColor
+        layer.shadowOffset = CGSize(width: 1, height: 1)
+        layer.shadowRadius = 2
+        layer.shadowOpacity = 1
+
+    }
+    
+}


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- 지출 셀의 디자인을 적용하였습니다.
- 지출 헤더의 디자인을 적용하였습니다.
- 지출 삭제기능을 추가하였습니다.
- 컬렉션뷰의 스크롤이 끝에 위치하도록 조정

## 리뷰노트
> 고민, 과정, 궁금한점

- 삭제기능을 구현하면서, 삭제처리가 될 핸들러를 cell 클래스의 메서드에 클로저로 전달하였습니다. 그런데 매번 데이터가 리로드 될 때마다 CellRegister 클래스가 비동기로 처리되는지, 도중에 등록했던 핸들러가 바뀌는 것을 보고 셀에 핸들러 프로퍼티를 만들고 셀의 프로퍼티에 직접 핸들러를 삽입해주는 방식으로 해결하였습니다.

## 스크린샷


https://user-images.githubusercontent.com/76734067/207225045-f83a44bc-0fcd-4ee6-87ae-713d30623470.mp4



