### PR TITLE
[장소 검색] 검색 결과가 없을 때 검색 실패 alert이 뜨는 현상 수정

### DIFF
--- a/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRemoteRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/TravelScene/SearchingLocation/SearchingLocationRemoteRepository.swift
@@ -20,7 +20,12 @@ final class SearchingLocationRemoteRepository: SearchingLocationRepository {
         
         let search = MKLocalSearch(request: request)
         search.start { response, error in
-            if error != nil { return completion(.failure(.invalidRequest)) }
+            if let error {
+                if let mkError = error as? MKError, mkError.code == .placemarkNotFound {
+                    return completion(.success([]))
+                }
+                return completion(.failure(.invalidRequest))
+            }
             
             guard let response
             else { return completion(.failure(.responseError)) }


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 검색 결과가 없는 상황과 검색에 실패한 상황이 구분되지 않는 문제를 수정했습니다.

## 리뷰노트
> 고민, 과정, 궁금한점
- 문제는 검색 결과가 없는 상황도 에러로 취급하는 `MKError`와, 에러가 발생하면 무조건 실패로 처리하도록 로직을 작성해둔 것이 콜라보를 일으켜 발생한 것이었읍니다... 다음은 MKError.Code의 케이스를 나타내고 있는데, 이 중 검색 결과가 없을 때 `placemarkNotFound` 라는 에러 코드를 반환하게 됩니다.
```objective-c
enum MKErrorCode {
   MKErrorUnknown = 1,
   MKErrorServerFailure,
   MKErrorLoadingThrottled,
   MKErrorPlacemarkNotFound,
};
```
- 이를 수정하기 위해 같은 에러라도 placemarkNotFound일 경우는 요청 성공 처리하고, 빈배열을 보내도록 수정했습니다.
- 그렇지만 에러가 발생했음에도 성공 처리하는 건 마음에 좀 걸리네요..😞

## 스크린샷

동일한 상황에서 버그 수정 전과 후의 모습입니다!

https://user-images.githubusercontent.com/50136980/207228091-16c8e403-218c-423e-b9d2-37c94ad39e48.mp4

https://user-images.githubusercontent.com/50136980/207226337-317498f3-540f-4476-bcf9-7888b36ccb10.mp4

