### PR TITLE
[지출 수정] 지출 상세화면 및 수정 기능 구현

### DIFF
--- a/Doesaegim/Doesaegim/App/Doesaegim.xcdatamodeld/Doesaegim.xcdatamodel/contents
+++ b/Doesaegim/Doesaegim/App/Doesaegim.xcdatamodeld/Doesaegim.xcdatamodel/contents
@@ -17,6 +17,7 @@
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="tradingStandardRate" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="travel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Travel" inverseName="expense" inverseEntity="Travel"/>
     </entity>
     <entity name="Location" representedClassName=".Location" syncable="YES" codeGenerationType="category">

--- a/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/ExpenseDTO.swift
+++ b/Doesaegim/Doesaegim/Data/DTO/PersistentDTO/ExpenseDTO.swift
@@ -15,5 +15,6 @@ struct ExpenseDTO {
     let cost: Int64
     let currency: String
     let date: Date
+    let tradingStandardRate: Double
     let travel: Travel
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddView.swift
@@ -180,12 +180,18 @@ final class ExpenseAddView: UIView {
         return button
     }()
     
+    // MARK: - Properties
+    
+    private let mode: ExpenseAddViewController.Mode
+    
     // MARK: - Lifecycles
     
-    override init(frame: CGRect) {
+    init(frame: CGRect, mode: ExpenseAddViewController.Mode) {
+        self.mode = mode
         super.init(frame: frame)
         backgroundColor = .white
         configureViews()
+        modeInit()
     }
     
     @available(*, unavailable)
@@ -205,14 +211,14 @@ final class ExpenseAddView: UIView {
         scrollView.addSubview(contentView)
         contentView.addSubviews(
             titleStackView, amountStackView, moneyUnitStackView, categoryStackView,
-            dateStackView, descriptionStackView, addButton
+            dateStackView, descriptionStackView
         )
         titleStackView.addArrangedSubviews(titleLabel, titleTextField)
         amountStackView.addArrangedSubviews(amountLabel, amountTextField)
         moneyUnitStackView.addArrangedSubviews(moneyUnitLabel, moneyUnitButton, moneyUnitExchangeLabel)
         categoryStackView.addArrangedSubviews(categoryLabel, categoryButton)
         dateStackView.addArrangedSubviews(dateLabel, dateButton)
-        descriptionStackView.addArrangedSubviews(descriptionTitleLabel, descriptionTextView)
+        descriptionStackView.addArrangedSubviews(descriptionTitleLabel, descriptionTextView, addButton)
         scrollView.addGestureRecognizer(UITapGestureRecognizer(
             target: self, action: #selector(backgroundDidTap)
         ))
@@ -276,6 +282,7 @@ final class ExpenseAddView: UIView {
         descriptionStackView.snp.makeConstraints {
             $0.top.equalTo(dateStackView.snp.bottom).offset(24)
             $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().offset(-30)
         }
         
         descriptionTextView.snp.makeConstraints {
@@ -283,11 +290,30 @@ final class ExpenseAddView: UIView {
         }
         
         addButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().offset(-30)
-            $0.top.equalTo(descriptionTextView.snp.bottom).offset(40)
+            
             $0.height.equalTo(48)
         }
+    }
+    
+    private func modeInit() {
+        switch mode {
+        case .detail:
+            setDetailMode()
+        case .update:
+            addButton.setTitle("지출 수정", for: .normal)
+        case .post:
+            addButton.setTitle("지출 추가", for: .normal)
+        }
+    }
+    
+    private func setDetailMode() {
+        titleTextField.isEnabled = false
+        amountTextField.isEnabled = false
+        moneyUnitButton.isEnabled = false
+        categoryButton.isEnabled = false
+        dateButton.isEnabled = false
+        descriptionTextView.isEditable = false
+        addButton.isHidden = true
     }
     
     @objc private func backgroundDidTap() {

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -13,13 +13,13 @@ final class ExpenseAddViewController: UIViewController {
     
     // MARK: - UI properties
     
-    private let rootView: ExpenseAddView
+    private var rootView: ExpenseAddView
     
     // MARK: - Properties
     
     private let viewModel: ExpenseAddViewModel
     private var exchangeInfo: ExchangeData?
-    private let mode: Mode
+    private var mode: Mode
     
     // MARK: - Lifecycles
     
@@ -51,13 +51,27 @@ final class ExpenseAddViewController: UIViewController {
     // MARK: - Configure Function
     
     private func configureNavigation() {
-        navigationItem.title = "지출 추가"
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: UIImage(systemName: "chevron.backward"),
             style: .done,
             target: self,
             action: #selector(backButtonTouchUpInside)
         )
+        navigationItem.rightBarButtonItem = nil
+        switch mode {
+        case .detail:
+            navigationItem.title = "지출 상세"
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                image: UIImage(systemName: "pencil"),
+                style: .done,
+                target: self,
+                action: #selector(updateButtonTapped)
+            )
+        case .post:
+            navigationItem.title = "지출 추가"
+        case .update:
+            navigationItem.title = "지출 수정"
+        }
     }
     
     // MARK: - AddTarget
@@ -111,6 +125,27 @@ final class ExpenseAddViewController: UIViewController {
             description: rootView.descriptionTextView.text
         )
     }
+    
+    @objc private func updateButtonTapped() {
+        let updateAction = UIAlertAction(
+            title: "수정하기",
+            style: .default
+        ) { [weak self] _ in
+            self?.mode = .update
+            self?.rootView = ExpenseAddView(frame: .zero, mode: .update)
+            self?.loadView()
+            self?.viewDidLoad()
+            self?.viewModel.isValidName = true
+            self?.viewModel.isValidAmount = true
+            self?.viewModel.isValidUnit = true
+            self?.viewModel.isValidCategory = true
+            self?.viewModel.isValidDate = true
+            self?.viewModel.isValidInput = true
+            
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        presentAlert(title: "지출 수정", message: "지출을 수정하시겠습니까?", actions: updateAction, cancelAction)
+    }
 }
 
 // MARK: - Actions
@@ -140,21 +175,45 @@ extension ExpenseAddViewController {
     }
     
     @objc func addButtonTouchUpInside() {
-        let result = viewModel.addExpense(
-            name: rootView.titleTextField.text,
-            category: rootView.categoryButton.titleLabel?.text,
-            content: rootView.descriptionTextView.text,
-            cost: rootView.amountTextField.text,
-            date: rootView.dateButton.titleLabel?.text,
-            exchangeInfo: exchangeInfo
-        )
-        switch result {
-        case .success:
-            navigationController?.popViewController(animated: true)
-        case .failure(let error):
-            print(error.localizedDescription)
-            presentErrorAlert(title: CoreDataError.saveFailure(.expense).errorDescription)
+        switch mode {
+        case .post:
+            let result = viewModel.addExpense(
+                name: rootView.titleTextField.text,
+                category: rootView.categoryButton.titleLabel?.text,
+                content: rootView.descriptionTextView.text,
+                cost: rootView.amountTextField.text,
+                date: rootView.dateButton.titleLabel?.text,
+                exchangeInfo: exchangeInfo
+            )
+            switch result {
+            case .success:
+                navigationController?.popViewController(animated: true)
+            case .failure(let error):
+                print(error.localizedDescription)
+                presentErrorAlert(title: CoreDataError.saveFailure(.expense).errorDescription)
+            }
+            
+        case .update:
+            let result = viewModel.updateExpense(
+                name: rootView.titleTextField.text,
+                category: rootView.categoryButton.titleLabel?.text,
+                content: rootView.descriptionTextView.text,
+                cost: rootView.amountTextField.text,
+                date: rootView.dateButton.titleLabel?.text,
+                exchangeInfo: exchangeInfo
+            )
+            switch result {
+            case .success:
+                navigationController?.popViewController(animated: true)
+            case .failure(let error):
+                print(error.localizedDescription)
+                presentErrorAlert(title: CoreDataError.saveFailure(.expense).errorDescription)
+            }
+            
+        case .detail:
+            break
         }
+        
     }
 }
 
@@ -223,7 +282,8 @@ extension ExpenseAddViewController: ExpenseAddViewDelegate {
     }
     
     func configureExpenseDetail(expense: Expense) {
-        guard let date = expense.date else { return }
+        guard let date = expense.date
+        else { return }
         rootView.titleTextField.text = expense.name
         // TODO: 수정해야함
         rootView.amountTextField.text = "\(expense.cost)"

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/View/ExpenseAddViewController.swift
@@ -389,6 +389,6 @@ extension ExpenseAddViewController {
 
 fileprivate extension ExpenseAddViewController {
     enum Metric {
-        static let amountTextFieldMaxCount: Int = 9
+        static let amountTextFieldMaxCount: Int = 7
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
@@ -146,7 +146,7 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
               let category,
               let exchangeInfo,
               let costString = cost,
-              let cost = Double(costString),
+              let cost = Int(costString),
               let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
               let dateString = date,
               let date = Date.yearMonthDayDateFormatter.date(from: dateString),
@@ -159,9 +159,10 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
             name: name,
             category: category,
             content: newContent,
-            cost: Int64(cost * tradingStandardRate * (1 / exchangeInfo.percent)),
+            cost: Int64(cost),
             currency: "\(exchangeRateType.icon) \(exchangeRateType.currencyName)",
             date: date,
+            tradingStandardRate: tradingStandardRate * (1 / exchangeInfo.percent),
             travel: travel)
         return repository.addExpense(expenseDTO)
     }
@@ -209,10 +210,9 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
     ) -> Result<Bool, Error> {
         guard let name,
               let category,
-              let exchangeInfo,
               let costString = cost,
-              let cost = Double(costString),
-              let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
+              let cost = Int64(costString),
+              
               let dateString = date,
               let date = Date.yearMonthDayDateFormatter.date(from: dateString),
               let expense
@@ -222,9 +222,15 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
         expense.name = name
         expense.content = content
         expense.date = date
-        expense.cost = Int64(cost * tradingStandardRate * (1 / exchangeInfo.percent))
+        expense.cost = Int64(cost)
         expense.category = category
-        expense.currency = exchangeInfo.currencyName
+        
+        if let exchangeInfo,
+           let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
+           let exchangeRateType = ExchangeRateType(rawValue: exchangeInfo.currencyCode) {
+            expense.currency = "\(exchangeRateType.icon) \(exchangeRateType.currencyName)"
+            expense.tradingStandardRate = tradingStandardRate
+        }
         return PersistentManager.shared.saveContext()
     }
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewModel.swift
@@ -39,20 +39,28 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
         }
     }
     
-    init(travel: Travel) {
+    var expense: Expense?
+    
+    init(travel: Travel, expenseID: UUID? = nil) {
         self.travel = travel
-        repository = ExpenseAddLocalRepository()
-        
         isValidName = false
         isValidAmount = false
         isValidUnit = false
         isValidCategory = false
         isValidDate = false
         isValidInput = isValidName && isValidAmount && isValidUnit && isValidCategory && isValidDate
-        
         exchangeCalculataion = 0
-        
         isClearInput = true
+        
+        repository = ExpenseAddLocalRepository()
+        
+        let result = repository.getExpenseDetail(with: expenseID)
+        switch result {
+        case .success(let expense):
+            self.expense = expense
+        case .failure:
+            self.expense = nil
+        }
     }
     
     // MARK: - Helpers
@@ -141,7 +149,8 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
               let cost = Double(costString),
               let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
               let dateString = date,
-              let date = Date.yearMonthDayDateFormatter.date(from: dateString)
+              let date = Date.yearMonthDayDateFormatter.date(from: dateString),
+              let exchangeRateType = ExchangeRateType(currencyCode: exchangeInfo.currencyCode)
                else {
             return .failure(CoreDataError.saveFailure(.expense))
         }
@@ -151,7 +160,7 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
             category: category,
             content: newContent,
             cost: Int64(cost * tradingStandardRate * (1 / exchangeInfo.percent)),
-            currency: exchangeInfo.currencyName,
+            currency: "\(exchangeRateType.icon) \(exchangeRateType.currencyName)",
             date: date,
             travel: travel)
         return repository.addExpense(expenseDTO)
@@ -183,6 +192,40 @@ final class ExpenseAddViewModel: ExpenseAddViewProtocol {
     
     func pickerViewInputButtonTapped(type: ExpenseAddPickerViewController.PickerType) {
         delegate?.presentExpenseAddPickerView(type: type)
+    }
+    
+    func fetchExpense() {
+        guard let expense else { return }
+        delegate?.configureExpenseDetail(expense: expense)
+    }
+    
+    func updateExpense(
+        name: String?,
+        category: String?,
+        content: String?,
+        cost: String?,
+        date: String?,
+        exchangeInfo: ExchangeData?
+    ) -> Result<Bool, Error> {
+        guard let name,
+              let category,
+              let exchangeInfo,
+              let costString = cost,
+              let cost = Double(costString),
+              let tradingStandardRate = Double(exchangeInfo.tradingStandardRate.convertRemoveComma()),
+              let dateString = date,
+              let date = Date.yearMonthDayDateFormatter.date(from: dateString),
+              let expense
+               else {
+            return .failure(CoreDataError.saveFailure(.expense))
+        }
+        expense.name = name
+        expense.content = content
+        expense.date = date
+        expense.cost = Int64(cost * tradingStandardRate * (1 / exchangeInfo.percent))
+        expense.category = category
+        expense.currency = exchangeInfo.currencyName
+        return PersistentManager.shared.saveContext()
     }
     
     

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseAdd/ViewModel/ExpenseAddViewProtocol.swift
@@ -55,4 +55,5 @@ protocol ExpenseAddViewDelegate: AnyObject {
     func presentExpenseAddPickerView(
         type: ExpenseAddPickerViewController.PickerType
     )
+    func configureExpenseDetail(expense: Expense)
 }

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/View/ExpenseListViewController.swift
@@ -28,8 +28,6 @@ final class ExpenseListViewController: UIViewController {
         
         collectionView.backgroundColor = .white
         collectionView.layer.cornerRadius = 12
-        collectionView.allowsSelection = false
-        
         return collectionView
     }()
     
@@ -228,7 +226,7 @@ final class ExpenseListViewController: UIViewController {
     @objc func didAddExpenseButtonTap() {
         guard let travel = viewModel?.currentTravel else { return }
         navigationController?.pushViewController(
-            ExpenseAddViewController(travel: travel),
+            ExpenseAddViewController(travel: travel, mode: .post),
             animated: true
         )
     }
@@ -276,7 +274,15 @@ extension ExpenseListViewController: ExpenseListViewModelDelegate {
 
 extension ExpenseListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        print(indexPath)
+        guard let expenseInfoViewModel = expenseDataSource?.itemIdentifier(for: indexPath),
+              let travel = viewModel?.currentTravel
+        else { return }
+        let expenseWriteViewController = ExpenseAddViewController(
+            travel: travel,
+            mode: .detail,
+            expenseID: expenseInfoViewModel.uuid
+        )
+        navigationController?.pushViewController(expenseWriteViewController, animated: true)
     }
 }
 

--- a/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/ExpenseScene/ExpenseList/ViewModel/ExpenseListViewModel.swift
@@ -70,28 +70,28 @@ extension ExpenseListViewModel {
     // 임시로 작성한 메서드. 추후 삭제 더미 지출 데이터를 추가한다.
     func addExpenseData() {
 
-        guard let travel = currentTravel else { return }
-        for count in 1...3 {
-            let dateComponents = DateComponents(year: 2022, month: 12, day: 25, hour: 17)
-            let date = Calendar.current.date(from: dateComponents)!
-            let dto = ExpenseDTO(
-                name: "\(count)번째 지출",
-                category: count == 1 ? "식비" : "교통비",
-                content: "식비입니다 콘텐츠 콘텐츠 콘텐츠",
-                cost: 10000,
-                currency: "KR",
-                date: date,
-                travel: travel
-            )
-            
-            let result = Expense.addAndSave(with: dto)
-            switch result {
-            case .success(let expense):
-                travel.addToExpense(expense)
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-        }
+//        guard let travel = currentTravel else { return }
+//        for count in 1...3 {
+//            let dateComponents = DateComponents(year: 2022, month: 12, day: 25, hour: 17)
+//            let date = Calendar.current.date(from: dateComponents)!
+//            let dto = ExpenseDTO(
+//                name: "\(count)번째 지출",
+//                category: count == 1 ? "식비" : "교통비",
+//                content: "식비입니다 콘텐츠 콘텐츠 콘텐츠",
+//                cost: 10000,
+//                currency: "KR",
+//                date: date,
+//                travel: travel
+//            )
+//            
+//            let result = Expense.addAndSave(with: dto)
+//            switch result {
+//            case .success(let expense):
+//                travel.addToExpense(expense)
+//            case .failure(let error):
+//                print(error.localizedDescription)
+//            }
+//        }
         
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddView.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddView.swift
@@ -141,11 +141,14 @@ final class PlanAddView: UIView {
         super.init(frame: frame)
         configureViews()
         setAddTarget()
-        if mode == .detail {
+        switch mode {
+        case .detail:
             setDetailMode()
+        case .update:
+            addButton.setTitle("일정 수정", for: .normal)
+        case .post:
+            addButton.setTitle("일정 추가", for: .normal)
         }
-        mode == .update ? addButton.setTitle("일정 수정", for: .normal)
-                        : addButton.setTitle("일정 추가", for: .normal)
     }
     
     @available(*, unavailable)
@@ -240,6 +243,17 @@ final class PlanAddView: UIView {
         descriptionTextView.isEditable = false
         addButton.isHidden = true
         placeSearchClearButton.isHidden = true
+    }
+    
+    private func modeInit() {
+        switch mode {
+        case .detail:
+            setDetailMode()
+        case .update:
+            addButton.setTitle("일정 수정", for: .normal)
+        case .post:
+            addButton.setTitle("일정 추가", for: .normal)
+        }
     }
     
     // MARK: - Keyboard

--- a/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/TravelScene/PlanAdd/View/PlanAddViewController.swift
@@ -49,7 +49,7 @@ final class PlanAddViewController: UIViewController {
         setKeyboardNotification()
         setDelegate()
         setAddTargets()
-        if mode == .detail || mode == .update {
+        if mode != .post {
             viewModel.fetchPlan()
         }
     }

--- a/Doesaegim/Doesaegim/Repository/ExpenseScene/ExpenseAdd/ExpenseAddLocalRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/ExpenseScene/ExpenseAdd/ExpenseAddLocalRepository.swift
@@ -8,7 +8,28 @@
 import Foundation
 
 struct ExpenseAddLocalRepository: ExpenseAddRepository {
+    
+    private let persistentManager = PersistentManager.shared
+    
     func addExpense(_ expenseDTO: ExpenseDTO) -> Result<Expense, Error> {
         Expense.addAndSave(with: expenseDTO)
+    }
+    
+    func getExpenseDetail(with id: UUID?) -> Result<Expense, CoreDataError> {
+        guard let id else {
+            return .failure(.fetchFailure(.expense))
+        }
+        
+        let result = persistentManager.fetch(request: Expense.fetchRequest())
+        
+        switch result {
+        case .success(let expenses):
+            guard let expense = expenses.first(where: { $0.id == id }) else {
+                return .failure(.fetchFailure(.expense))
+            }
+            return .success(expense)
+        case .failure:
+            return .failure(.fetchFailure(.expense))
+        }
     }
 }

--- a/Doesaegim/Doesaegim/Repository/ExpenseScene/ExpenseAdd/ExpenseAddRepository.swift
+++ b/Doesaegim/Doesaegim/Repository/ExpenseScene/ExpenseAdd/ExpenseAddRepository.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol ExpenseAddRepository {
     func addExpense(_ expenseDTO: ExpenseDTO) -> Result<Expense, Error>
+    func getExpenseDetail(with id: UUID?) -> Result<Expense, CoreDataError>
 }

--- a/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
+++ b/Doesaegim/NSManagedObjectClass/Expense+CoreDataClass.swift
@@ -25,6 +25,7 @@ public class Expense: NSManagedObject {
         expense.category = object.category
         expense.currency = object.currency
         expense.cost = object.cost
+        expense.tradingStandardRate = object.tradingStandardRate
         object.travel.addToExpense(expense)
         
         let result = PersistentManager.shared.saveContext()


### PR DESCRIPTION
## 변경사항
* 지출 상세화면을 구현하였습니다.
* 지출 수정기능을 구현하였습니다.
* 최대 지출 입력금액을 9자리에서 7자리로 줄였습니다.

## 리뷰노트
* 지출을 추가할 때, cost 프로퍼티 하나만 가지고는 상세보기에서 지출액수를 표시할 수 없어 지출을 추가할 때, 환율도 입력받을 수 있도록 Expense 객체를 수정하였습니다.
* 지출목록 셀에서 cost로 금액을 보여주고 있던 것을 cost * 환율로 수정해야합니다.
  * 재훈님께서 지출목록화면을 업데이트 해주셔서 머지가 된 후 수정하겠습니다.

## 스크린샷
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/77199797/207239317-23dee75a-759b-4124-8366-6445b8157864.gif)
