### PR TITLE
[커스텀 그래프] 버그 수정

### DIFF
--- a/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/BarChart/BarTextLayer.swift
@@ -57,6 +57,5 @@ final class BarTextLayer: CATextLayer {
         )
         string = attributedString
         alignmentMode = alignment ?? .center
-        truncationMode = .end
     }
 }

--- a/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
+++ b/Doesaegim/Doesaegim/Utility/CustomGraph/PieChart/CustomPieChart.swift
@@ -77,12 +77,13 @@ final class CustomPieChart: UIView {
     /// 주어진 rect에 맞게 원형 차트를 그린다. 원형 차트는 정원 형태로 영역에 꽉 채워서 그려진다.
     /// - Parameter rect: 원형 차트를 그릴 영역.
     override func draw(_ rect: CGRect) {
+        initializeAnimation()
+
         if isAnimating {
             drawOnePiece(with: currentItem, on: rect)
             return
         }
         
-        initializeAnimation()
         for index in items.indices {
             currentIndex = index
             drawOnePiece(with: currentItem, on: rect)
@@ -184,7 +185,7 @@ extension CustomPieChart: CAAnimationDelegate {
         
         startAngle += ratio * Metric.angle
         currentIndex += 1
-        setNeedsDisplay()
+        drawOnePiece(with: currentItem, on: bounds)
     }
 }
 


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 
- 민석님이 알려주신 특정 상황에서 파이차트가 그려지지 않는 문제를 수정했습니다.
- 막대 차트의 좌측 금액 단위를 잘라 표시하지 않도록 수정했습니다.

## 리뷰노트
> 고민, 과정, 궁금한점
- 파이 차트의 애니메이션은 원래 다음과 같은 방식으로 동작했습니다.
  1. 파이차트는 식비, 교통비, 숙박비, 관광비, 기타의 고정된 순서로 그려집니다.
  2. draw 메서드가 실행되면 지출 내역 중 제일 먼저 그려져야하는 지출 타입을 찾아 적절하게 파이 조각을 만들어 이를 애니메이션과 함께 그립니다.
  3. 첫번째 파이조각의 애니메이션이 끝나면 `CAAnimationDelegate`의 `animationDidStop`이 실행됩니다.
  4. 다음으로 그려야할 지출 타입이 있다면 다음 순서를 저장하고, setNeedsDisplay를 통해 draw 메서드를 재실행합니다.
  5. 더 이상 그릴 파이 조각이 없다면 그대로 종료합니다.
- 이 과정이 대체 뭐가 문제인가!! 하고 열심히 찾아본 결과, 테스트 했을 때 식비가 전체 비율 중 매우 작은 부분을 차지하고, 이를 각도로 반환했을 때 0.13도라는 결과가 나왔습니다. 정확한 이유는 알 수 없지만 이렇게 첫번째 조각이 그려진 후 4번 과정의 setNeedsDisplay가 실행되지 않았고, 이후 큰 비중을 차지하는 파이 조각이 그려지지 않아 전체 그래프가 그려지지 않는 것처럼 보였던 것 같습니다..
- 파이 한 조각을 그리는 부분을 별도 메서드(drawOnePiece)로 구현에 두었기에, 4번 과정의 setNeedsDisplay를 drawOnePiece 메서드로 대체했습니다..!
- 또한 막대차트처럼 중복 레이어가 추가되는 것을 막기 위해 initializeAnimation 메서드를 draw 실행 시 제일 먼저 실행되도록 수정했습니다.

## 스크린샷

https://user-images.githubusercontent.com/50136980/207243173-a1473682-d878-4419-9c4b-752b561e7b34.mp4

