### PR TITLE
hotfix: 블러처리 뷰에서 공유하기 버튼 누락 문제 해결

### DIFF
--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/BlurredImageViewController.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/View/BlurredImageViewController.swift
@@ -79,27 +79,26 @@ final class BlurredImageViewController: UIViewController {
     }
 
     private func configureNavigationBar() {
-        guard let image = imageView.image
-        else {
-            return
-        }
-
         let shareButton = UIBarButtonItem(image: .init(systemName: StringLiteral.shareButtonImage))
         shareButton.tintColor = .systemOrange
 
         let sharedToActivityViewController = UIAction(
             title: StringLiteral.shareButtonTitle
         ) { [weak self] _ in
-            guard let self
+            guard let self,
+                  let image = self.imageView.image
             else {
+                self?.presentErrorAlert(title: StringLiteral.missingImageAlertTitle)
                 return
             }
 
             ShareManager.shared.shareToActivityViewController(with: image, to: self)
         }
         let sharedToInstagramStory = UIAction(title: StringLiteral.instagramButtonTitle) { [weak self] _ in
-            guard let self
+            guard let self,
+                  let image = self.imageView.image
             else {
+                self?.presentErrorAlert(title: StringLiteral.missingImageAlertTitle)
                 return
             }
 
@@ -125,5 +124,7 @@ fileprivate extension BlurredImageViewController {
         static let shareButtonTitle = "공유하기"
 
         static let instagramButtonTitle = "인스타그램 스토리로 공유하기"
+
+        static let missingImageAlertTitle = "공유할 사진이 없습니다"
     }
 }

--- a/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
+++ b/Doesaegim/Doesaegim/Presentation/DiaryScene/FaceDetection/ViewModel/BlurredImageViewModel.swift
@@ -28,7 +28,7 @@ final class BlurredImageViewModel {
     }
 
 
-    // MARK: Functions
+    // MARK: - Functions
 
     func applyFilter() {
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in


### PR DESCRIPTION
## 변경사항
> 변경사항 간략하게 

- 블러 처리 뷰에서 공유하기 버튼이 누락되던 문제를 해결했습니다. 
  - 이미지가 있을때만 버튼을 나타내고 싶어서 guard문을 썼었는데 블러처리를 백그라운드 스레드에 async로 보내면서 처리된 이미지를 전달받기 전에 버튼이 초기화되는 문제였습니다...

## 리뷰노트
> 고민, 과정, 궁금한점

## 스크린샷


https://user-images.githubusercontent.com/81314063/207603150-10e31014-dbaa-4628-baf5-8f0b9ca39498.MP4


